### PR TITLE
Tss 63 - NULL check on tcti_tabrmd_XXXX functions

### DIFF
--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -50,7 +50,10 @@ tss2_tcti_tabrmd_transmit (TSS2_TCTI_CONTEXT *context,
     TSS2_RC tss2_ret = TSS2_RC_SUCCESS;
 
     g_debug ("tss2_tcti_tabrmd_transmit");
-    if ((context == NULL) || (size == 0) || (command == NULL)) {
+    if (context == NULL) {
+      return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
+    if ((size == 0) || (command == NULL)) {
       return TSS2_TCTI_RC_BAD_VALUE;
     }
     if (TSS2_TCTI_MAGIC (context) != TSS2_TCTI_TABRMD_MAGIC ||
@@ -172,7 +175,10 @@ tss2_tcti_tabrmd_receive (TSS2_TCTI_CONTEXT *context,
     size_t ret = 0;
 
     g_debug ("tss2_tcti_tabrmd_receive");
-    if ((context == NULL) || (size == 0) || (response == NULL)) {
+    if (context == NULL) {
+      return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
+    if ((size == 0) || (response == NULL)) {
       return TSS2_TCTI_RC_BAD_VALUE;
     }
     if (TSS2_TCTI_MAGIC (context) != TSS2_TCTI_TABRMD_MAGIC ||
@@ -255,6 +261,10 @@ tss2_tcti_tabrmd_finalize (TSS2_TCTI_CONTEXT *context)
     int ret = 0;
 
     g_debug ("tss2_tcti_tabrmd_finalize");
+    if (context == NULL) {
+      g_warning ("Invalid parameter");
+      return;
+    }
     if (TSS2_TCTI_TABRMD_FD_RECEIVE (context) != 0) {
         ret = close (TSS2_TCTI_TABRMD_FD_RECEIVE (context));
         TSS2_TCTI_TABRMD_FD_RECEIVE (context) = 0;
@@ -282,6 +292,9 @@ tss2_tcti_tabrmd_cancel (TSS2_TCTI_CONTEXT *context)
 
     g_info("tss2_tcti_tabrmd_cancel: id 0x%" PRIx64,
            TSS2_TCTI_TABRMD_ID (context));
+    if (context == NULL) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
     if (TSS2_TCTI_TABRMD_STATE (context) != TABRMD_STATE_RECEIVE) {
         return TSS2_TCTI_RC_BAD_SEQUENCE;
     }
@@ -305,6 +318,9 @@ tss2_tcti_tabrmd_get_poll_handles (TSS2_TCTI_CONTEXT     *context,
                                    TSS2_TCTI_POLL_HANDLE *handles,
                                    size_t                *num_handles)
 {
+    if (context == NULL) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
     if (num_handles == NULL) {
         return TSS2_TCTI_RC_BAD_REFERENCE;
     }
@@ -328,6 +344,9 @@ tss2_tcti_tabrmd_set_locality (TSS2_TCTI_CONTEXT *context,
 
     g_info ("tss2_tcti_tabrmd_set_locality: id 0x%" PRIx64,
             TSS2_TCTI_TABRMD_ID (context));
+    if (context == NULL) {
+      return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
     if (TSS2_TCTI_TABRMD_STATE (context) != TABRMD_STATE_TRANSMIT) {
         return TSS2_TCTI_RC_BAD_SEQUENCE;
     }


### PR DESCRIPTION
Updated the NULL checks.
Having problem with building unit test for these changes. 
Given these are changes are obvious, will skip the unit test for these for now.
