### PR TITLE
ResourceManager: Remove unref of connection object when flushing contexts

### DIFF
--- a/src/resource-manager.c
+++ b/src/resource-manager.c
@@ -439,7 +439,6 @@ resource_manager_process_tpm2_command (ResourceManager   *resmgr,
     case TPM_CC_FlushContext:
         g_debug ("processing TPM_CC_FlushContext");
         response = resource_manager_flush_context (resmgr, command);
-        g_object_unref (connection);
         break;
     default:
         /* Load contexts and switch virtual to physical handles in command */


### PR DESCRIPTION
…hing contexts.

This caused any use of ContextFlush to result in the connection being
closed. That's bad.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>