### PR TITLE
Clean up data read and client termination log messages.

### DIFF
--- a/src/command-source.c
+++ b/src/command-source.c
@@ -322,10 +322,10 @@ fail_out:
     if (buf != NULL) {
         g_free (buf);
     }
-    g_warning ("removing connection 0x%" PRIxPTR " from connection_manager "
-               "0x%" PRIxPTR,
-               (uintptr_t)connection,
-               (uintptr_t)source->connection_manager);
+    g_debug ("removing connection 0x%" PRIxPTR " from connection_manager "
+             "0x%" PRIxPTR,
+             (uintptr_t)connection,
+             (uintptr_t)source->connection_manager);
     FD_CLR (fd, &source->receive_fdset);
     connection_manager_remove (source->connection_manager,
                                connection);

--- a/src/util.c
+++ b/src/util.c
@@ -156,8 +156,8 @@ read_data (int                       fd,
         errno_tmp = errno;
         switch (num_read) {
         case -1: /* error */
-            g_debug ("read produced error: %d, %s",
-                     errno_tmp, strerror (errno_tmp));
+            g_warning ("read on fd %d produced error: %d, %s",
+                       fd, errno_tmp, strerror (errno_tmp));
             return errno_tmp;
         case 0:  /* EOF / fd closed */
             g_debug ("read produced EOF");


### PR DESCRIPTION
The read_data message output a debug message when `read` returns -1.
This is an error condition. Using 'warning' makes more sense.

The CommandSource object largely doesn't care why the connection was
closed only that the associated data it be cleaned up properly. The
message output when a client connection fails shouldn't be a warning,
just a debug message.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>