### PR TITLE
tabrmd: Remove debug function exposed over dbus.

### DIFF
--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -330,76 +330,6 @@ on_handle_set_locality (TctiTabrmd            *skeleton,
 
     return TRUE;
 }
-void
-dump_trans_state_callback (gpointer key,
-                           gpointer value,
-                           gpointer user_data)
-{
-    TPM_HANDLE phandle;
-    HandleMapEntry *entry;
-
-    g_debug ("dump_trans_state_callback: key: 0x%" PRIxPTR " value: 0x%"
-             PRIxPTR " user_data: 0x%" PRIxPTR,
-             (uintptr_t)key, (uintptr_t)value, (uintptr_t)user_data);
-    phandle = (TPM_HANDLE)(uintptr_t)key;
-    if (value == NULL) {
-        g_warning ("got NULL entry for key: 0x%" PRIx32, phandle);
-        return;
-    }
-    entry = HANDLE_MAP_ENTRY (value);
-
-    g_debug ("  dump_trans_state_callback entry:   0x%" PRIxPTR,
-             (uintptr_t)entry);
-    g_debug ("  dump_trans_state_callback phandle: 0x%" PRIx32, phandle);
-    g_debug ("  dump_trans_state_callback vhandle: 0x%" PRIx32,
-             handle_map_entry_get_vhandle (entry));
-    g_debug ("  dump_trans_state_callback_context: 0x%" PRIxPTR,
-             (uintptr_t)handle_map_entry_get_context (entry));
-}
-/*
- */
-static gboolean
-on_handle_dump_trans_state (TctiTabrmd            *skeleton,
-                            GDBusMethodInvocation *invocation,
-                            gint64                 id,
-                            gpointer               user_data)
-{
-    gmain_data_t *data = (gmain_data_t*)user_data;
-    HandleMap      *map     = NULL;
-    Connection   *connection = NULL;
-    GVariant *uint32_variant, *tuple_variant;
-    const gchar *name = NULL;
-
-    g_info ("on_handle_dump_trans_state");
-    name = g_dbus_method_invocation_get_sender (invocation);
-    if (name == NULL) {
-        g_dbus_method_invocation_return_error (
-            invocation,
-            TABRMD_ERROR,
-            TABRMD_ERROR_INTERNAL,
-            "Failed to get client name");
-        return TRUE;
-    }
-    g_debug ("on_handle_dump_trans_state for id %s", name);
-    g_mutex_lock (&data->init_mutex);
-    g_mutex_unlock (&data->init_mutex);
-    connection = connection_manager_lookup_id (data->manager, name);
-    if (connection == NULL)
-        g_error ("no active connection for id: %s", name);
-    g_info ("dumping transient handle map for for connection 0x%" PRIxPTR,
-            (uintptr_t)connection);
-    map = connection_get_trans_map (connection);
-    g_object_unref (connection);
-    g_info ("  number of entries in map: %" PRIu32, handle_map_size (map));
-    handle_map_foreach (map, dump_trans_state_callback, NULL);
-    g_object_unref (map);
-    /* setup and send return value */
-    uint32_variant = g_variant_new_uint32 (TSS2_RC_SUCCESS);
-    tuple_variant = g_variant_new_tuple (&uint32_variant, 1);
-    g_dbus_method_invocation_return_value (invocation, tuple_variant);
-
-    return TRUE;
-}
 /**
  * This is a signal handler of type GBusAcquiredCallback. It is registered
  * by the g_bus_own_name function and invoked then a connectiont to a bus
@@ -449,10 +379,6 @@ on_name_acquired (GDBusConnection *connection,
     g_signal_connect (gmain_data->skeleton,
                       "handle-set-locality",
                       G_CALLBACK (on_handle_set_locality),
-                      user_data);
-    g_signal_connect (gmain_data->skeleton,
-                      "handle-dump-trans-state",
-                      G_CALLBACK (on_handle_dump_trans_state),
                       user_data);
     ret = g_dbus_interface_skeleton_export (
         G_DBUS_INTERFACE_SKELETON (gmain_data->skeleton),

--- a/src/tabrmd.xml
+++ b/src/tabrmd.xml
@@ -12,8 +12,5 @@
             <arg type='y'  name='locality'     direction='in'/>
             <arg type='u'  name='return_code'  direction='out'/>
         </method>
-        <method name='DumpTransState'>
-            <arg type='u'  name='return_code'  direction='out'/>
-        </method>
     </interface>
 </node>

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -368,27 +368,6 @@ tss2_tcti_tabrmd_set_locality (TSS2_TCTI_CONTEXT *context,
     return ret;
 }
 
-TSS2_RC
-tss2_tcti_tabrmd_dump_trans_state (TSS2_TCTI_CONTEXT *context)
-{
-    gboolean status;
-    TSS2_RC ret;
-    GError *error = NULL;
-
-    g_info ("tss2_tcti_tabrmd_dump_state");
-    status = tcti_tabrmd_call_dump_trans_state_sync (
-                 TSS2_TCTI_TABRMD_PROXY (context),
-                 &ret,
-                 NULL,
-                 &error);
-    if (status == FALSE) {
-        g_warning ("dump_trans_state command failed: %s", error->message);
-        g_error_free (error);
-        return TSS2_TCTI_RC_GENERAL_FAILURE;
-    }
-
-    return ret;
-}
 /*
  * Initialization function to set context data values and function pointers.
  */

--- a/test/integration/create-keys.c
+++ b/test/integration/create-keys.c
@@ -43,7 +43,6 @@
 int
 test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 {
-    TSS2_TCTI_CONTEXT *tcti_context;
     TPM_HANDLE         parent_handle, out_handle;
     TPM2B_PRIVATE      out_private = TPM2B_PRIVATE_STATIC_INIT;
     TPM2B_PUBLIC       out_public  = { 0 };
@@ -76,13 +75,6 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         if (rc != TSS2_RC_SUCCESS)
             g_error ("Failed to create_key: 0x%" PRIx32, rc);
         out_public.t.size = 0;
-    }
-
-    rc = Tss2_Sys_GetTctiContext (sapi_context, &tcti_context);
-    if (rc != TSS2_RC_SUCCESS && tcti_context != NULL) {
-        rc = tss2_tcti_tabrmd_dump_trans_state (tcti_context);
-        if (rc != TSS2_RC_SUCCESS)
-            g_error ("failed to dump transient object state");
     }
 
     return rc;


### PR DESCRIPTION
This was a mechanism to allow a client to cause the daemon to dump the
state of the transient object mgmt structures. The right way to do this
would be a separate DBus API that allows callers to query for various
tabrmd state, not unlike the TPMs GetCapability function.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>