### PR TITLE
docs: Use coveralls badge from shields.io instead of coveralls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/intel/tpm2-abrmd.svg?branch=master)](https://travis-ci.org/intel/tpm2-abrmd)
 [![Coverity Scan](https://img.shields.io/coverity/scan/3997.svg)](https://scan.coverity.com/projects/01org-tpm2-abrmd)
-[![Coverage Status](https://coveralls.io/repos/github/intel/tpm2-abrmd/badge.svg?branch=1.x)](https://coveralls.io/github/intel/tpm2-abrmd?branch=1.x)
+[![Coverage Status](https://img.shields.io/coveralls/github/intel/tpm2-abrmd/1.x.svg)](https://coveralls.io/github/intel/tpm2-abrmd)
 
 # TPM2 Access Broker & Resource Manager
 This is a system daemon implementing the TPM2 access broker (TAB) & Resource


### PR DESCRIPTION
According to https://github.com/lemurheavy/coveralls-public/issues/116
the github web caching is aggressive to the point of causing the badge
URL provided by coveralls to show old cached values for a very long
time. A number of hacks were proposed but the most sane seemed to be to
use the badge provided by shields.io instead as it doesn't suffer from
the same issue as the one from coveralls.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>