### PR TITLE
[1.x] test: Fix hardware test failure

### DIFF
--- a/scripts/int-hardware-setup.sh
+++ b/scripts/int-hardware-setup.sh
@@ -96,7 +96,7 @@ echo "dbus-daemon PID: ${PID}"
 TABRMD_LOG_FILE=${TEST_BIN}_tabrmd.log
 TABRMD_PID_FILE=${TEST_BIN}_tabrmd.pid
 TABRMD_NAME=com.intel.tss2.Tabrmd${PID}
-tabrmd_start ${TABRMD_BIN} ${TABRMD_NAME} ${TABRMD_LOG_FILE} ${TABRMD_PID_FILE}
+tabrmd_start ${TABRMD_BIN} 0 ${TABRMD_NAME} ${TABRMD_LOG_FILE} ${TABRMD_PID_FILE}
 if [ $? -ne 0 ]; then
     echo "failed to start tabrmd with name ${TABRMD_NAME}"
 fi


### PR DESCRIPTION
The commit 1aa9cbd28d8b
("test: Refactor common code from test support scripts into script
library.") dropped the definition of dbus_daemon_start() so
--enable-test-hwtpm doesn't work as expected.

Additionally, simulator and hardware tests distinguishing from each
other use port number to pass different parameters to tabrmd daemon.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>