### PR TITLE
1.x SELinux: Remove gen_require part from tpm-abrmd2 policy.

### DIFF
--- a/selinux/tabrmd.te
+++ b/selinux/tabrmd.te
@@ -15,12 +15,8 @@ dev_rw_tpm(tabrmd_t)
 logging_send_syslog_msg(tabrmd_t)
 
 optional_policy(`
+    dbus_stub()
     dbus_system_domain(tabrmd_t, tabrmd_exec_t)
+    allow system_dbusd_t tabrmd_t:unix_stream_socket rw_stream_socket_perms;
 ')
 
-# This next bit doesn't belong here. It should be exposed through an
-# interface likely from the dbus policy module.
-gen_require(`
-    type system_dbusd_t;
-')
-allow system_dbusd_t tabrmd_t:unix_stream_socket { read write };


### PR DESCRIPTION
This pull request contains a cherry-pick from master commit b61499e4a290 ("[SELinux] Remove gen_require part from tpm-abrmd2 policy."), that didn't made to the 1.x branch.

@flihp it would be great if you can cut a minor release with this commit, that way distros can update the tpm2-abmrd package with a correct SELinux policy module.