### PR TITLE
Fix the inappropriate use of g_error with GError.

### DIFF
--- a/src/ipc-frontend-dbus.c
+++ b/src/ipc-frontend-dbus.c
@@ -266,9 +266,8 @@ get_pid_from_dbus_invocation (GDBusProxy            *proxy,
                                      NULL,
                                      &error);
     if (error) {
-        g_error ("Unable to get PID for %s: %s", name, error->message);
+        g_warning ("Unable to get PID for %s: %s", name, error->message);
         g_error_free (error);
-        error = NULL;
         return FALSE;
     } else {
         g_variant_get (result, "(u)", pid);

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -474,7 +474,8 @@ tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT      *context,
             NULL,                          /* GCancellable* */
             &error);
     if (TSS2_TCTI_TABRMD_PROXY (context) == NULL) {
-        g_error ("failed to allocate dbus proxy object: %s", error->message);
+        g_critical ("failed to allocate dbus proxy object: %s", error->message);
+        return TSS2_TCTI_RC_NO_CONNECTION;
     }
     call_ret = tcti_tabrmd_call_create_connection_sync_fdlist (
         TSS2_TCTI_TABRMD_PROXY (context),


### PR DESCRIPTION
This commit is try to fix this issue https://github.com/tpm2-software/tpm2-abrmd/issues/96 .