### PR TITLE
Rename TctiOptions to TctiFactory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -233,8 +233,8 @@ src_libutil_la_SOURCES = \
     src/tabrmd.h \
     src/tcti.c \
     src/tcti.h \
-    src/tcti-options.c \
-    src/tcti-options.h \
+    src/tcti-factory.c \
+    src/tcti-factory.h \
     src/tcti-type-enum.c \
     src/tcti-type-enum.h \
     src/thread.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,7 @@ TESTS_UNIT = \
     test/session-entry_unit \
     test/test-skeleton_unit \
     test/tcti-echo_unit \
+    test/tcti-factory_unit \
     test/thread_unit \
     test/tpm2-command_unit \
     test/tpm2-response_unit \
@@ -446,6 +447,10 @@ test_resource_manager_unit_CFLAGS  = $(UNIT_AM_CFLAGS)
 test_resource_manager_unit_LDFLAGS = -Wl,--wrap=access_broker_send_command,--wrap=sink_enqueue,--wrap=access_broker_context_saveflush,--wrap=access_broker_context_load
 test_resource_manager_unit_LDADD   = $(CMOCKA_LIBS) $(GLIB_LIBS) $(GOBJECT_LIBS) $(SAPI_LIBS) $(PTHREAD_LIBS) $(libutil) $(libtcti_echo)
 test_resource_manager_unit_SOURCES = test/resource-manager_unit.c
+
+test_tcti_factory_unit_CFLAGS  = $(UNIT_AM_CFLAGS)
+test_tcti_factory_unit_LDADD   = $(CMOCKA_LIBS) $(GLIB_LIBS) $(GOBJECT_LIBS) $(libutil)
+test_tcti_factory_unit_SOURCES = test/tcti-factory_unit.c
 
 test_tcti_echo_unit_CFLAGS  = $(UNIT_AM_CFLAGS)
 test_tcti_echo_unit_LDADD   = $(CMOCKA_LIBS) $(GLIB_LIBS) $(GOBJECT_LIBS) $(libutil) $(libtcti_echo)

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -49,7 +49,6 @@
 #include "resource-manager.h"
 #include "response-sink.h"
 #include "source-interface.h"
-#include "tcti-options.h"
 #include "util.h"
 
 /* Structure to hold data that we pass to the gmain loop as 'user_data'.
@@ -334,7 +333,7 @@ parse_opts (gint            argc,
 
     ctx = g_option_context_new (" - TPM2 software stack Access Broker Daemon (tabrmd)");
     g_option_context_add_main_entries (ctx, entries, NULL);
-    g_option_context_add_group (ctx, tcti_options_get_group (options->tcti_options));
+    g_option_context_add_group (ctx, tcti_factory_get_group (options->tcti_factory));
     if (!g_option_context_parse (ctx, &argc, &argv, &err)) {
         tabrmd_critical ("Failed to parse options: %s", err->message);
     }
@@ -393,9 +392,9 @@ main (int argc, char *argv[])
 
     g_info ("tabrmd startup");
     /* instantiate a TctiOptions object for the parse_opts function to use */
-    gmain_data.options.tcti_options = tcti_options_new ();
+    gmain_data.options.tcti_factory = tcti_factory_new ();
     parse_opts (argc, argv, &gmain_data.options);
-    gmain_data.tcti = tcti_options_get_tcti (gmain_data.options.tcti_options);
+    gmain_data.tcti = tcti_factory_get_tcti (gmain_data.options.tcti_factory);
 
     g_mutex_init (&gmain_data.init_mutex);
     gmain_data.loop = g_main_loop_new (NULL, FALSE);
@@ -419,7 +418,7 @@ main (int argc, char *argv[])
     thread_cleanup (THREAD (gmain_data.resource_manager));
     thread_cleanup (THREAD (gmain_data.response_sink));
     /* clean up what remains */
-    g_object_unref (gmain_data.options.tcti_options);
+    g_object_unref (gmain_data.options.tcti_factory);
     g_object_unref (gmain_data.random);
     g_object_unref (gmain_data.tcti);
     return 0;

--- a/src/tabrmd.h
+++ b/src/tabrmd.h
@@ -30,7 +30,7 @@
 #include <gio/gio.h>
 #include <sapi/tpm20.h>
 
-#include "tcti-options.h"
+#include "tcti-factory.h"
 #include "tcti-tabrmd.h"
 
 #define TABRMD_DBUS_INTERFACE_DEFAULT        TCTI_TABRMD_DBUS_INTERFACE_DEFAULT
@@ -61,7 +61,7 @@
 
 typedef struct tabrmd_options {
     GBusType        bus;
-    TctiOptions    *tcti_options;
+    TctiFactory    *tcti_factory;
     gboolean        fail_on_loaded_trans;
     gboolean        flush_all;
     guint           max_connections;

--- a/src/tcti-factory.h
+++ b/src/tcti-factory.h
@@ -24,8 +24,19 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef TCTI_OPTIONS_H
-#define TCTI_OPTIONS_H
+/*
+ * The TctiOption object is a slightly missnamed factory object responsible
+ * for instantiating TCTI objects. Additionally this object encapsulates all
+ * knowledge of TCTI options and so we provide a _get_group function that
+ * returns a GOptionGroup that the caller can use to provide users with info
+ * about the supported TCTIs and the structure of their parameters.
+ * Once this GOptionGroup has been used to collect arguments from the
+ * commandline then the caller may call _get_tcti to get the factory to
+ * produce / return a Tcti object configured according to the options
+ * provided.
+ */
+#ifndef TCTI_FACTORY_H
+#define TCTI_FACTORY_H
 
 #include <glib-object.h>
 #include "tcti.h"
@@ -37,30 +48,30 @@ G_BEGIN_DECLS
 #define G_OPTION_FLAG_NONE 0
 #endif
 
-typedef struct _TctiOptionsClass {
+typedef struct _TctiFactoryClass {
     GObjectClass     parent;
-} TctiOptionsClass;
+} TctiFactoryClass;
 
-typedef struct _TctiOptions
+typedef struct _TctiFactory
 {
     GObject          parent_instance;
     TctiTypeEnum     tcti_type;
     gchar           *device_name;
     gchar           *socket_address;
     guint            socket_port;
-} TctiOptions;
+} TctiFactory;
 
-#define TYPE_TCTI_OPTIONS             (tcti_options_get_type       ())
-#define TCTI_OPTIONS(obj)             (G_TYPE_CHECK_INSTANCE_CAST ((obj),   TYPE_TCTI_OPTIONS, TctiOptions))
-#define TCTI_OPTIONS_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST    ((klass), TYPE_TCTI_OPTIONS, TctiOptionsClass))
-#define IS_TCTI_OPTIONS(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj),   TYPE_TCTI_OPTIONS))
-#define IS_TCTI_OPTIONS_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE    ((klass), TYPE_TCTI_OPTIONS))
-#define TCTI_OPTIONS_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS  ((obj),   TYPE_TCTI_OPTIONS, TctiOptionsClass))
+#define TYPE_TCTI_FACTORY             (tcti_factory_get_type       ())
+#define TCTI_FACTORY(obj)             (G_TYPE_CHECK_INSTANCE_CAST ((obj),   TYPE_TCTI_FACTORY, TctiFactory))
+#define TCTI_FACTORY_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST    ((klass), TYPE_TCTI_FACTORY, TctiFactoryClass))
+#define IS_TCTI_FACTORY(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj),   TYPE_TCTI_FACTORY))
+#define IS_TCTI_FACTORY_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE    ((klass), TYPE_TCTI_FACTORY))
+#define TCTI_FACTORY_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS  ((obj),   TYPE_TCTI_FACTORY, TctiFactoryClass))
 
-GType         tcti_options_get_type  (void);
-TctiOptions*  tcti_options_new       (void);
-GOptionGroup* tcti_options_get_group (TctiOptions *options);
-Tcti*         tcti_options_get_tcti  (TctiOptions *options);
+GType         tcti_factory_get_type  (void);
+TctiFactory*  tcti_factory_new       (void);
+GOptionGroup* tcti_factory_get_group (TctiFactory *options);
+Tcti*         tcti_factory_get_tcti  (TctiFactory *options);
 
 G_END_DECLS
-#endif /* TCTI_OPTIONS_H */
+#endif /* TCTI_FACTORY_H */

--- a/test/tcti-factory_unit.c
+++ b/test/tcti-factory_unit.c
@@ -36,24 +36,24 @@
 #ifdef HAVE_TCTI_SOCKET
 #include "tcti-socket.h"
 #endif
-#include "tcti-options.h"
+#include "tcti-factory.h"
 
 /**
- * Very simple setup / teardown functions to instantiate a TctiOptions
+ * Very simple setup / teardown functions to instantiate a TctiFactory
  * object and unref it.
  */
 static int
-tcti_options_setup (void **state)
+tcti_factory_setup (void **state)
 {
-    *state = tcti_options_new ();
+    *state = tcti_factory_new ();
     return 0;
 }
 static int
-tcti_options_teardown (void **state)
+tcti_factory_teardown (void **state)
 {
-    TctiOptions *tcti_options = TCTI_OPTIONS (*state);
+    TctiFactory *tcti_factory = TCTI_FACTORY (*state);
 
-    g_object_unref (tcti_options);
+    g_object_unref (tcti_factory);
     return 0;
 }
 /**
@@ -62,9 +62,9 @@ tcti_options_teardown (void **state)
  * valgrind.
  */
 static void
-tcti_options_new_unref_test (void **state)
+tcti_factory_new_unref_test (void **state)
 {
-    TctiOptions *tcti_opts = TCTI_OPTIONS (*state);
+    TctiFactory *tcti_opts = TCTI_FACTORY (*state);
 
     assert_non_null (tcti_opts);
 }
@@ -75,28 +75,28 @@ tcti_options_new_unref_test (void **state)
  */
 #ifdef HAVE_TCTI_DEVICE
 static void
-tcti_options_defaults_device_test (void **state)
+tcti_factory_defaults_device_test (void **state)
 {
-    TctiOptions *tcti_options = TCTI_OPTIONS (*state);
+    TctiFactory *tcti_factory = TCTI_FACTORY (*state);
 
-    assert_string_equal (tcti_options->device_name, TCTI_DEVICE_DEFAULT_FILE);
+    assert_string_equal (tcti_factory->device_name, TCTI_DEVICE_DEFAULT_FILE);
 }
 #endif
 #ifdef HAVE_TCTI_SOCKET
 static void
-tcti_options_defaults_socket_address_test (void **state)
+tcti_factory_defaults_socket_address_test (void **state)
 {
-    TctiOptions *tcti_options = TCTI_OPTIONS (*state);
+    TctiFactory *tcti_factory = TCTI_FACTORY (*state);
 
-    assert_string_equal (tcti_options->socket_address,
+    assert_string_equal (tcti_factory->socket_address,
                          TCTI_SOCKET_DEFAULT_HOST);
 }
 static void
-tcti_options_defaults_socket_port_test (void **state)
+tcti_factory_defaults_socket_port_test (void **state)
 {
-    TctiOptions *tcti_options = TCTI_OPTIONS (*state);
+    TctiFactory *tcti_factory = TCTI_FACTORY (*state);
 
-    assert_int_equal (tcti_options->socket_port,
+    assert_int_equal (tcti_factory->socket_port,
                       TCTI_SOCKET_DEFAULT_PORT);
 }
 #endif
@@ -106,21 +106,21 @@ main (gint     argc,
       gchar   *argv[])
 {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown (tcti_options_new_unref_test,
-                                         tcti_options_setup,
-                                         tcti_options_teardown),
+        cmocka_unit_test_setup_teardown (tcti_factory_new_unref_test,
+                                         tcti_factory_setup,
+                                         tcti_factory_teardown),
 #ifdef HAVE_TCTI_DEVICE
-        cmocka_unit_test_setup_teardown (tcti_options_defaults_device_test,
-                                         tcti_options_setup,
-                                         tcti_options_teardown),
+        cmocka_unit_test_setup_teardown (tcti_factory_defaults_device_test,
+                                         tcti_factory_setup,
+                                         tcti_factory_teardown),
 #endif
 #ifdef HAVE_TCTI_SOCKET
-        cmocka_unit_test_setup_teardown (tcti_options_defaults_socket_address_test,
-                                         tcti_options_setup,
-                                         tcti_options_teardown),
-        cmocka_unit_test_setup_teardown (tcti_options_defaults_socket_port_test,
-                                         tcti_options_setup,
-                                         tcti_options_teardown),
+        cmocka_unit_test_setup_teardown (tcti_factory_defaults_socket_address_test,
+                                         tcti_factory_setup,
+                                         tcti_factory_teardown),
+        cmocka_unit_test_setup_teardown (tcti_factory_defaults_socket_port_test,
+                                         tcti_factory_setup,
+                                         tcti_factory_teardown),
 #endif
     };
     return cmocka_run_group_tests (tests, NULL, NULL);


### PR DESCRIPTION
This is a simple rename of the object and re-enabling of the associated unit test. I couldn't find anything in the VCS that shows this unit test being disabled so it could be that I just never remembered to add it to the test harness in the first place.