### PR TITLE
tcti-dynamic: Add support for dynamic loading of TCTIs and standard i…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ TESTS_UNIT = \
     test/random_unit \
     test/session-entry_unit \
     test/test-skeleton_unit \
+    test/tcti-dynamic_unit \
     test/tcti-echo_unit \
     test/tcti-factory_unit \
     test/thread_unit \
@@ -238,6 +239,8 @@ src_libutil_la_SOURCES = \
     src/tabrmd.h \
     src/tcti.c \
     src/tcti.h \
+    src/tcti-dynamic.c \
+    src/tcti-dynamic.h \
     src/tcti-factory.c \
     src/tcti-factory.h \
     src/tcti-type-enum.c \
@@ -451,6 +454,11 @@ test_resource_manager_unit_CFLAGS  = $(UNIT_AM_CFLAGS)
 test_resource_manager_unit_LDFLAGS = -Wl,--wrap=access_broker_send_command,--wrap=sink_enqueue,--wrap=access_broker_context_saveflush,--wrap=access_broker_context_load
 test_resource_manager_unit_LDADD   = $(CMOCKA_LIBS) $(GLIB_LIBS) $(GOBJECT_LIBS) $(SAPI_LIBS) $(PTHREAD_LIBS) $(libutil) $(libtcti_echo)
 test_resource_manager_unit_SOURCES = test/resource-manager_unit.c
+
+test_tcti_dynamic_unit_CFLAGS   = $(UNIT_AM_CFLAGS)
+test_tcti_dynamic_unit_LDADD    = $(CMOCKA_LIBS) $(GLIB_LIBS) $(GOBJECT_LIBS) $(libutil)
+test_tcti_dynamic_unit_LDFLAGS  = -Wl,--wrap=dlopen,--wrap=dlsym,--wrap=dlclose
+test_tcti_dynamic_unit_SOURCES  = test/tcti-dynamic_unit.c
 
 test_tcti_factory_unit_CFLAGS  = $(UNIT_AM_CFLAGS)
 test_tcti_factory_unit_LDADD   = $(CMOCKA_LIBS) $(GLIB_LIBS) $(GOBJECT_LIBS) $(libutil)

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,11 @@ AS_IF([test "x$enable_unit" != xno],
                                     [1],
                                     [cmocka is available])])])
 AM_CONDITIONAL([UNIT], [test "x$enable_unit" != xno])
+
+# -dl or -dld
+AC_SEARCH_LIBS([dlopen], [dl dld], [], [
+  AC_MSG_ERROR([unable to find the dlopen() function])
+])
 PKG_CHECK_MODULES([DBUS], [dbus-1])
 PKG_CHECK_MODULES([GIO], [gio-unix-2.0])
 PKG_CHECK_MODULES([GLIB], [glib-2.0])

--- a/man/tpm2-abrmd.8.in
+++ b/man/tpm2-abrmd.8.in
@@ -1,7 +1,7 @@
 .\" Process this file with
 .\" groff -man -Tascii foo.1
 .\"
-.TH TPM2-ABRMD 8 "APRIL 2017" Intel "TPM2 Software Stack"
+.TH TPM2-ABRMD 8 "February 2018" Intel "TPM2 Software Stack"
 .SH NAME
 tpm2-abrmd \- TPM2 access broker and resource management daemon
 .SH SYNOPSIS
@@ -53,11 +53,12 @@ Read seed for pseudo-random number generator from the provided file.
 \fB\-s,\ \-\-session\fR
 Connect daemon to the session dbus. This option overrides the default
 behavior.
+.SH TCTI Specific Options
 .TP
 \fB\-t,\ \-\-tcti\fR
 Select the TCTI used by tabd for communication with the next component down
 the TSS stack. In most configurations this will be the TPM but it could be
-a simulator or proxy. Supported TCTIs are \fB\*(lqnone\*(rq\fR
+a simulator or proxy. Supported TCTIs are \fB\*(lqdynamic\*(rq\fR
 .if (\n[HAVE_DEVICE_TCTI]) or \fB\*(lqdevice\*(rq\fR
 .if (\n[HAVE_SOCKET_TCTI]) or \fB\*(lqsocket\*(rq\fR
 \[char46]
@@ -76,6 +77,15 @@ is 127.0.0.1.
 \fB\-p,\ \-\-tcti-socket-port\fR
 Specify the port number used by the socket TCTI. The default is 2321.
 \}
+.TP
+\fB\-i,\ \-\-tcti-file-name\fR
+Pass the name of the TCTI library to load using the 'dynamic' TCTI loading
+mechanism. Values for this parameter will depend on the TCTI. Libraries are
+found using the same algorithm as dlopen (3).
+.TP
+\fB\-j,\ \-\-tcti-conf-str\fR
+Specify the configureation string passed to the TCTI during the 'dynamic'
+loading and initialization. The format for this string is TCTI specific.
 .TP
 \fB\-v,\ \-\-version\fR
 Disply version string.

--- a/src/tcti-dynamic.c
+++ b/src/tcti-dynamic.c
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2018, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dlfcn.h>
+#include <inttypes.h>
+
+#include "tabrmd.h"
+#include "tcti-dynamic.h"
+
+G_DEFINE_TYPE (TctiDynamic, tcti_dynamic, TYPE_TCTI);
+
+enum {
+    PROP_0,
+    PROP_FILE_NAME,
+    PROP_CONF_STR,
+    N_PROPERTIES
+};
+static GParamSpec *obj_properties[N_PROPERTIES] = { NULL, };
+
+static void
+tcti_dynamic_set_property (GObject      *object,
+                          guint         property_id,
+                          const GValue *value,
+                          GParamSpec   *pspec)
+{
+    TctiDynamic *self = TCTI_DYNAMIC (object);
+
+    switch (property_id) {
+    case PROP_FILE_NAME:
+        self->file_name = g_value_dup_string (value);
+        g_debug ("%s: TctiDynamic 0x%" PRIxPTR " set filename: %s",
+                 __func__, (uintptr_t)self, self->file_name);
+        break;
+    case PROP_CONF_STR:
+        self->conf_str = g_value_dup_string (value);
+        g_debug ("%s: TctiDynamic 0x%" PRIxPTR " PROP_CONF_STR set to: %s",
+                 __func__, (uintptr_t)self, self->conf_str);
+        break;
+    default:
+        /* We don't have any other property... */
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+        break;
+    }
+}
+static void
+tcti_dynamic_get_property (GObject    *object,
+                          guint       property_id,
+                          GValue     *value,
+                          GParamSpec *pspec)
+{
+    TctiDynamic *self = TCTI_DYNAMIC (object);
+
+    g_debug ("%s: TctiDynamic 0x%" PRIxPTR, __func__, (uintptr_t)self);
+    switch (property_id) {
+    case PROP_FILE_NAME:
+        g_value_set_string (value, self->file_name);
+        break;
+    case PROP_CONF_STR:
+        g_value_set_string (value, self->conf_str);
+        break;
+    default:
+        /* We don't have any other property... */
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+        break;
+    }
+}
+/*
+ * Override the parent finalize method so we can free the data associated with
+ * the TctiDynamic instance.
+ */
+static void
+tcti_dynamic_finalize (GObject *obj)
+{
+    Tcti          *tcti        = TCTI (obj);
+    TctiDynamic    *tcti_dynamic = TCTI_DYNAMIC (obj);
+
+    if (tcti->tcti_context) {
+        tss2_tcti_finalize (tcti->tcti_context);
+    }
+    g_clear_pointer (&tcti->tcti_context, g_free);
+    g_clear_pointer (&tcti_dynamic->file_name, g_free);
+    g_clear_pointer (&tcti_dynamic->conf_str, g_free);
+    G_OBJECT_CLASS (tcti_dynamic_parent_class)->finalize (obj);
+}
+static void
+tcti_dynamic_init (TctiDynamic *tcti)
+{ /* noop */ }
+/*
+ * When the class is initialized we set the pointer to our finalize function.
+ */
+static void
+tcti_dynamic_class_init (TctiDynamicClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+    TctiClass    *tcti_class   = TCTI_CLASS (klass);
+
+    if (tcti_dynamic_parent_class == NULL)
+        tcti_dynamic_parent_class = g_type_class_peek_parent (klass);
+
+    object_class->finalize     = tcti_dynamic_finalize;
+    object_class->get_property = tcti_dynamic_get_property;
+    object_class->set_property = tcti_dynamic_set_property;
+
+    tcti_class->initialize = (TctiInitFunc)tcti_dynamic_initialize;
+
+    obj_properties[PROP_FILE_NAME] =
+        g_param_spec_string ("file-name",
+                             "TCTI library file",
+                             "Library file containing TCTI implementation.",
+                             "tcti-device.so",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+    obj_properties[PROP_CONF_STR] =
+        g_param_spec_string ("conf-str",
+                             "TCTI config string",
+                             "TCTI initialization configuration string.",
+                             "empty string",
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+    g_object_class_install_properties (object_class,
+                                       N_PROPERTIES,
+                                       obj_properties);
+}
+/*
+ * Instantiate a new TctiDynamic object.
+ */
+TctiDynamic*
+tcti_dynamic_new (const gchar *file_name,
+                  const gchar *conf_str)
+{
+    return TCTI_DYNAMIC (g_object_new (TYPE_TCTI_DYNAMIC,
+                                       "file-name", file_name,
+                                       "conf-str", conf_str,
+                                       NULL));
+}
+
+TSS2_RC
+tcti_dynamic_discover_info (TctiDynamic *self)
+{
+    TSS2_TCTI_INFO_FUNC info_func;
+    void *tcti_dl_handle;
+
+    g_debug ("%s: TctiDynamic 0x%" PRIxPTR, __func__, (uintptr_t)self);
+    tcti_dl_handle = dlopen (self->file_name, RTLD_LAZY);
+    if (tcti_dl_handle == NULL) {
+        g_warning ("failed to dlopen file %s: %s", self->file_name, dlerror ());
+        return TSS2_RESMGR_RC_BAD_VALUE;
+    }
+    info_func = dlsym (tcti_dl_handle, TSS2_TCTI_INFO_SYMBOL);
+    if (info_func == NULL) {
+        g_warning ("Failed to get reference to symbol: %s", dlerror ());
+        dlclose (tcti_dl_handle);
+        return TSS2_RESMGR_RC_BAD_VALUE;
+    }
+    self->tcti_info = info_func ();
+    dlclose (tcti_dl_handle);
+    return TSS2_RC_SUCCESS;
+}
+/*
+ * Initialize an instance of a TSS2_TCTI_CONTEXT for the device TCTI.
+ */
+TSS2_RC
+tcti_dynamic_initialize (TctiDynamic *self)
+{
+    Tcti          *tcti     = TCTI (self);
+    TSS2_RC        rc       = TSS2_RC_SUCCESS;
+    size_t         ctx_size;
+
+    /*
+     * This should be done through the GInitable interface.
+     */
+    rc = tcti_dynamic_discover_info (self);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+    g_debug ("%s: TctiDynamic 0x%" PRIxPTR, __func__, (uintptr_t)self);
+    if (self->tcti_info == NULL || self->tcti_info->init == NULL) {
+        g_warning ("%s: TCTI_INFO structure or init function pointer is NULL, "
+                   "cannot initialize context.", __func__);
+        return TSS2_RESMGR_RC_BAD_VALUE;
+    }
+    rc = self->tcti_info->init (NULL, &ctx_size, NULL);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_warning ("failed to get size for device TCTI contexxt structure: "
+                   "0x%x", rc);
+        goto out;
+    }
+    tcti->tcti_context = g_malloc0 (ctx_size);
+    if (tcti->tcti_context == NULL) {
+        g_warning ("failed to allocate memory");
+        rc = TSS2_RESMGR_RC_INTERNAL_ERROR;
+        goto out;
+    }
+    rc = self->tcti_info->init (tcti->tcti_context, &ctx_size, self->conf_str);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_warning ("failed to initialize device TCTI context: 0x%x", rc);
+        g_free (tcti->tcti_context);
+        tcti->tcti_context = NULL;
+    }
+out:
+    return rc;
+}

--- a/src/tcti-dynamic.h
+++ b/src/tcti-dynamic.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef TABD_TCTI_DYNAMIC_H
+#define TABD_TCTI_DYNAMIC_H
+
+#include <sapi/tpm20.h>
+#include <glib-object.h>
+
+#include "tcti.h"
+
+G_BEGIN_DECLS
+
+#define TCTI_DYNAMIC_DEFAULT_FILE_NAME "tcti-device.so"
+#define TCTI_DYNAMIC_DEFAULT_CONF_STR  "/dev/tpm0"
+
+typedef struct _TctiDynamicClass {
+   TctiClass           parent;
+} TctiDynamicClass;
+
+typedef struct _TctiDynamic
+{
+    Tcti               parent_instance;
+    gchar             *file_name;
+    gchar             *conf_str;
+    const TSS2_TCTI_INFO *tcti_info;
+} TctiDynamic;
+
+#define TYPE_TCTI_DYNAMIC             (tcti_dynamic_get_type       ())
+#define TCTI_DYNAMIC(obj)             (G_TYPE_CHECK_INSTANCE_CAST ((obj),   TYPE_TCTI_DYNAMIC, TctiDynamic))
+#define TCTI_DYNAMIC_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST    ((klass), TYPE_TCTI_DYNAMIC, TctiDynamicClass))
+#define IS_TCTI_DYNAMIC(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj),   TYPE_TCTI_DYNAMIC))
+#define IS_TCTI_DYNAMIC_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE    ((klass), TYPE_TCTI_DYNAMIC))
+#define TCTI_DYNAMIC_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS  ((obj),   TYPE_TCTI_DYNAMIC, TctiDynamicClass))
+
+GType                tcti_dynamic_get_type       (void);
+TctiDynamic*         tcti_dynamic_new            (gchar const      *file_name,
+                                                  gchar const      *conf_str);
+TSS2_RC              tcti_dynamic_discover_info  (TctiDynamic      *tcti);
+TSS2_RC              tcti_dynamic_initialize     (TctiDynamic      *tcti);
+
+G_END_DECLS
+#endif /* TABD_TCTI_DYNAMIC_H */

--- a/src/tcti-factory.h
+++ b/src/tcti-factory.h
@@ -59,6 +59,8 @@ typedef struct _TctiFactory
     gchar           *device_name;
     gchar           *socket_address;
     guint            socket_port;
+    gchar           *file_name;
+    gchar           *conf_str;
 } TctiFactory;
 
 #define TYPE_TCTI_FACTORY             (tcti_factory_get_type       ())

--- a/src/tcti-type-enum.c
+++ b/src/tcti-type-enum.c
@@ -40,6 +40,7 @@ tcti_type_enum_get_type (void)
 #ifdef HAVE_TCTI_SOCKET
             { TCTI_TYPE_SOCKET, "TCTI for tcp socket", "socket" },
 #endif
+            { TCTI_TYPE_DYNAMIC, "Dynamic TCTI loading.", "dynamic" },
             { 0, NULL, NULL }
         };
 

--- a/src/tcti-type-enum.h
+++ b/src/tcti-type-enum.h
@@ -52,6 +52,7 @@ typedef enum TCTI_TYPE {
 #ifdef HAVE_TCTI_SOCKET
     TCTI_TYPE_SOCKET,
 #endif
+    TCTI_TYPE_DYNAMIC,
 } TctiTypeEnum;
 
 #define TYPE_TCTI_TYPE_ENUM      (tcti_type_enum_get_type ())

--- a/test/tcti-dynamic_unit.c
+++ b/test/tcti-dynamic_unit.c
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <glib.h>
+#include <stdlib.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "tcti-dynamic.h"
+#include "tabrmd.h"
+
+#define TCTI_DYNAMIC_UNIT_FILE_NAME "tss2-mytcti.so"
+#define TCTI_DYNAMIC_UNIT_CONF_STR  "tss2-mytcti-conf-str"
+#define TCTI_DYNAMIC_UNIT_HANDLE    (uintptr_t)0xcafebabecafe
+
+#define TCTI_DYNAMIC_UNIT_INIT_1_FAIL_RC 0xdeadbeef
+#define TCTI_DYNAMIC_UNIT_INIT_2_FAIL_RC 0xbeefdead
+#define TCTI_DYNAMIC_UNIT_INIT_SIZE 10
+
+void* __real_dlopen (const char *filename, int flags);
+void*
+__wrap_dlopen (const char *file_name,
+               int flags)
+{
+    if (strcmp (file_name, TCTI_DYNAMIC_UNIT_FILE_NAME)) {
+        return __real_dlopen (file_name, flags);
+    }
+    return mock_type (void*);
+}
+
+void* __real_dlsym(void *handle, const char *symbol);
+void*
+__wrap_dlsym (void *handle, const char *symbol)
+{
+    if ((uintptr_t)handle != TCTI_DYNAMIC_UNIT_HANDLE || strcmp (symbol, TSS2_TCTI_INFO_SYMBOL)) {
+        return __real_dlsym (handle, symbol);
+    }
+    return mock_type (void*);
+}
+
+int __real_dlclose(void *handle);
+int
+__wrap_dlclose (void *handle)
+{
+    if ((uintptr_t)handle != TCTI_DYNAMIC_UNIT_HANDLE) {
+        return __real_dlclose (handle);
+    }
+    return mock_type (int);
+}
+
+static TSS2_TCTI_INFO*
+tcti_dynamic_get_info_null (void)
+{
+    return NULL;
+}
+/*
+ * This dummy structure is returned by the fake info function below. It is
+ * a dummy value used in testing the `tcti_dynamic_discover_info` function.
+ */
+static TSS2_TCTI_INFO tcti_info_empty = {
+    .init = NULL,
+};
+/*
+ * This function is used when we mock the dlsym function. We cause dlsym to
+ * return a reference to this function as a way to have the mock function
+ * return a valid reference to an info function.
+ */
+static TSS2_TCTI_INFO*
+tcti_dynamic_get_info_empty (void)
+{
+    return &tcti_info_empty;
+}
+/*
+ * This is a fake TCTI initialization function that returns an error code
+ * unique to this test module. This is how we test error handling around
+ * the execution of the init function.
+ */
+static TSS2_RC
+tcti_dynamic_init_fail (TSS2_TCTI_CONTEXT *context,
+                        size_t *size,
+                        const char *conf_str)
+{
+    return TCTI_DYNAMIC_UNIT_INIT_1_FAIL_RC;
+}
+/*
+ * This is an info struct populated with an initialization function that
+ * fails in a predictable way.
+ */
+static TSS2_TCTI_INFO tcti_info_init_1_fail = {
+    .init = tcti_dynamic_init_fail,
+};
+/*
+ * This function conforms to the TSS2_TCTI_INFO_FUNC prototype. It returns an
+ * info structure populated with an init function that fails with an RC unique
+ * to this test.
+ */
+static TSS2_TCTI_INFO*
+tcti_dynamic_get_info_init_1_fail (void)
+{
+    return &tcti_info_init_1_fail;
+}
+/*
+ * Just like the init_fail function above this init function will return an error
+ * but only if the context provided is non-null. This is how we test error
+ * handling around the second invocation of the init function.
+ */
+static TSS2_RC
+tcti_dynamic_init_2_fail (TSS2_TCTI_CONTEXT *context,
+                          size_t *size,
+                          const char *conf_str)
+{
+    if (context == NULL) {
+        *size = TCTI_DYNAMIC_UNIT_INIT_SIZE;
+        return TSS2_RC_SUCCESS;
+    } else {
+        return TCTI_DYNAMIC_UNIT_INIT_2_FAIL_RC;
+    }
+}
+static TSS2_TCTI_INFO tcti_info_init_2_fail = {
+    .init = tcti_dynamic_init_2_fail,
+};
+static TSS2_TCTI_INFO*
+tcti_dynamic_get_info_init_2_fail (void)
+{
+    return &tcti_info_init_2_fail;
+}
+/*
+ * cmocka setup function. Just allocate the object and store in state.
+ */
+static int
+tcti_dynamic_setup (void **state)
+{
+    *state = tcti_dynamic_new (TCTI_DYNAMIC_UNIT_FILE_NAME,
+                               TCTI_DYNAMIC_UNIT_CONF_STR);
+    return 0;
+}
+/*
+ * cmocka teardown function. Unref the object.
+ */
+static int
+tcti_dynamic_teardown (void **state)
+{
+    TctiDynamic *tcti_dynamic = TCTI_DYNAMIC (*state);
+
+    g_object_unref (tcti_dynamic);
+    return 0;
+}
+/*
+ * Test object life cycle: create new object then unref it.
+ */
+static void
+tcti_dynamic_new_unref_test (void **state)
+{
+    assert_non_null (*state);
+    assert_true (IS_TCTI (*state));
+    assert_true (IS_TCTI_DYNAMIC (*state));
+}
+/*
+ * Cause a failure (NULL context) to be returned by dlopen while the
+ * TctiDynamic is trying to load the requested shared object.
+ */
+static void
+tcti_dynamic_discover_info_dlopen_fail_test (void **state)
+{
+    TctiDynamic *tcti_dynamic = TCTI_DYNAMIC (*state);
+    TSS2_RC rc;
+
+    will_return (__wrap_dlopen, NULL);
+    rc = tcti_dynamic_discover_info (tcti_dynamic);
+    assert_int_equal (rc, TSS2_RESMGR_RC_BAD_VALUE);
+}
+/*
+ * Cause a failure in the tcti_dynamic_discover_info function by causing the
+ * dlsym function to return a NULL pointer.
+ */
+static void
+tcti_dynamic_discover_info_dlsym_fail_test (void **state)
+{
+    TctiDynamic *tcti_dynamic = TCTI_DYNAMIC (*state);
+    TSS2_RC rc;
+
+    will_return (__wrap_dlopen, TCTI_DYNAMIC_UNIT_HANDLE);
+    will_return (__wrap_dlsym, NULL);
+    will_return (__wrap_dlclose, 0);
+    rc = tcti_dynamic_discover_info (tcti_dynamic);
+    assert_int_equal (rc, TSS2_RESMGR_RC_BAD_VALUE);
+}
+/*
+ * Cause the dynamic_tcti_discover_info function to execute successfully.
+ * This requires that we:
+ * 1) mock a successful call to dlopen
+ * 2) mock a call to dlsym such that it returns a fake TCTI info function that
+ *    will return a valid INFO structure.
+ * 3) mock a successful call to dlclose
+ * 4) check the return type etc
+ */
+static void
+tcti_dynamic_discover_info_func_success_test (void **state)
+{
+    TctiDynamic *tcti_dynamic = TCTI_DYNAMIC (*state);
+    TSS2_RC rc;
+
+    will_return (__wrap_dlopen, TCTI_DYNAMIC_UNIT_HANDLE);
+    will_return (__wrap_dlsym, tcti_dynamic_get_info_empty);
+    will_return (__wrap_dlclose, 0);
+    rc = tcti_dynamic_discover_info (tcti_dynamic);
+    assert_int_equal (rc, TSS2_RC_SUCCESS);
+    assert_ptr_equal (tcti_dynamic->tcti_info, &tcti_info_empty);
+}
+/*
+ * Cause a failure in the tcti_dynamic_discover_info function by causing
+ * dlsym to return a reference to a valid TCTI info function, but one that
+ * returns a NULL info struct. This shouldn't happen and if it does the
+ * TCTI is violating the spec but checking for it isn't a bad thing.
+ */
+static void
+tcti_dynamic_initialize_bad_info_test (void **state)
+{
+    TctiDynamic *tcti_dynamic = TCTI_DYNAMIC (*state);
+    TSS2_RC rc;
+
+    will_return (__wrap_dlopen, TCTI_DYNAMIC_UNIT_HANDLE);
+    will_return (__wrap_dlsym, tcti_dynamic_get_info_null);
+    will_return (__wrap_dlclose, 0);
+    rc = tcti_dynamic_initialize (tcti_dynamic);
+    assert_int_equal (rc, TSS2_RESMGR_RC_BAD_VALUE);
+}
+/*
+ * This test exercises a test for a NULL init function pointer returned by
+ * a TCTI modules 'info' function.
+ */
+static void
+tcti_dynamic_initialize_null_init_test (void **state)
+{
+    TctiDynamic *tcti_dynamic = TCTI_DYNAMIC (*state);
+    TSS2_RC rc;
+
+    will_return (__wrap_dlopen, TCTI_DYNAMIC_UNIT_HANDLE);
+    will_return (__wrap_dlsym, tcti_dynamic_get_info_empty);
+    will_return (__wrap_dlclose, 0);
+    rc = tcti_dynamic_initialize (tcti_dynamic);
+    assert_int_equal (rc, TSS2_RESMGR_RC_BAD_VALUE);
+}
+/*
+ * This test causes the first call to the TCTI init function returned by
+ * way of the INFO structure to fail with a known RC.
+ */
+static void
+tcti_dynamic_initialize_init_1_fail_test (void **state)
+{
+    TctiDynamic *tcti_dynamic = TCTI_DYNAMIC (*state);
+    TSS2_RC rc;
+
+    will_return (__wrap_dlopen, TCTI_DYNAMIC_UNIT_HANDLE);
+    will_return (__wrap_dlsym, tcti_dynamic_get_info_init_1_fail);
+    will_return (__wrap_dlclose, 0);
+    rc = tcti_dynamic_initialize (tcti_dynamic);
+    assert_int_equal (rc, TCTI_DYNAMIC_UNIT_INIT_1_FAIL_RC);
+}
+/*
+ * This tests failure handling around the second invocation of the init function.
+ */
+static void
+tcti_dynamic_initialize_init_2_fail_test (void **state)
+{
+    TctiDynamic *tcti_dynamic = TCTI_DYNAMIC (*state);
+    TSS2_RC rc;
+
+    will_return (__wrap_dlopen, TCTI_DYNAMIC_UNIT_HANDLE);
+    will_return (__wrap_dlsym, tcti_dynamic_get_info_init_2_fail);
+    will_return (__wrap_dlclose, 0);
+    rc = tcti_dynamic_initialize (tcti_dynamic);
+    assert_int_equal (rc, TCTI_DYNAMIC_UNIT_INIT_2_FAIL_RC);
+}
+gint
+main (gint     argc,
+      gchar   *argv[])
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown (tcti_dynamic_new_unref_test,
+                                         tcti_dynamic_setup,
+                                         tcti_dynamic_teardown),
+        cmocka_unit_test_setup_teardown (tcti_dynamic_discover_info_dlopen_fail_test,
+                                         tcti_dynamic_setup,
+                                         tcti_dynamic_teardown),
+        cmocka_unit_test_setup_teardown (tcti_dynamic_discover_info_dlsym_fail_test,
+                                         tcti_dynamic_setup,
+                                         tcti_dynamic_teardown),
+        cmocka_unit_test_setup_teardown (tcti_dynamic_discover_info_func_success_test,
+                                         tcti_dynamic_setup,
+                                         tcti_dynamic_teardown),
+        cmocka_unit_test_setup_teardown (tcti_dynamic_initialize_bad_info_test,
+                                         tcti_dynamic_setup,
+                                         tcti_dynamic_teardown),
+        cmocka_unit_test_setup_teardown (tcti_dynamic_initialize_null_init_test,
+                                         tcti_dynamic_setup,
+                                         tcti_dynamic_teardown),
+        cmocka_unit_test_setup_teardown (tcti_dynamic_initialize_init_1_fail_test,
+                                         tcti_dynamic_setup,
+                                         tcti_dynamic_teardown),
+        cmocka_unit_test_setup_teardown (tcti_dynamic_initialize_init_2_fail_test,
+                                         tcti_dynamic_setup,
+                                         tcti_dynamic_teardown),
+    };
+    return cmocka_run_group_tests (tests, NULL, NULL);
+}


### PR DESCRIPTION
…nit.

This integrates a new Tcti object into the daemon. The TctiFactory knows
it as "dynamic". it's selected by providing `--tcti=dynamic` on the
command line. Two more options are provided to allow for selection of the
TCTI library (same search rules as `dlopen`) and a configuration string.
To use this interface the TCTI must support the new initialization mechanism
currently being standardized.

The tabrmd manpage is also updated for the new options associated with the
new TCTI loading / initialization mechanism.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>