### PR TITLE
integration test dynamic TCTI

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -437,85 +437,73 @@ test_tss2_tcti_echo_unit_LDADD   = $(CMOCKA_LIBS) $(libtcti_echo)
 test_tss2_tcti_echo_unit_SOURCES = test/tss2-tcti-echo_unit.c
 endif
 
-test_integration_auth_session_max_int_LDADD   = $(libtest) $(libtcti_tabrmd) \
-    $(GLIB_LIBS)
+TEST_INT_LIBS = $(libtest) $(libutil) $(libtcti_tabrmd) $(GLIB_LIBS)
+test_integration_auth_session_max_int_LDADD = $(TEST_INT_LIBS)
 test_integration_auth_session_max_int_SOURCES = test/integration/main.c \
     test/integration/auth-session-max.int.c
 
-test_integration_auth_session_start_flush_int_LDADD   = $(libtest) $(libtcti_tabrmd) \
-    $(GLIB_LIBS)
+test_integration_auth_session_start_flush_int_LDADD = $(TEST_INT_LIBS)
 test_integration_auth_session_start_flush_int_SOURCES = test/integration/main.c \
     test/integration/auth-session-start-flush.int.c
 
-test_integration_auth_session_start_save_int_LDADD   = $(libtest) $(libtcti_tabrmd) \
-    $(GLIB_LIBS)
+test_integration_auth_session_start_save_int_LDADD = $(TEST_INT_LIBS)
 test_integration_auth_session_start_save_int_SOURCES = test/integration/main.c \
     test/integration/auth-session-start-save.int.c
 
-test_integration_auth_session_start_save_load_int_LDADD   = $(libtest) $(libtcti_tabrmd) \
-    $(GLIB_LIBS)
+test_integration_auth_session_start_save_load_int_LDADD = $(TEST_INT_LIBS)
 test_integration_auth_session_start_save_load_int_SOURCES = test/integration/main.c \
     test/integration/auth-session-start-save-load.int.c
 
-test_integration_create_keys_int_LDADD   = $(libtest) $(libtcti_tabrmd) \
-    $(GLIB_LIBS) $(GOBJECT_LIBS) $(SAPI_LIBS) $(TCTI_DEVICE_LIBS) \
-    $(TCTI_SOCKET_LIBS)
+test_integration_create_keys_int_LDADD = $(TEST_INT_LIBS)
 test_integration_create_keys_int_SOURCES = test/integration/main.c test/integration/create-keys.int.c
 
-test_integration_get_capability_handles_transient_int_LDADD   = $(libtest) \
-    $(libtcti_tabrmd) $(GLIB_LIBS) $(SAPI_LIBS)
+test_integration_get_capability_handles_transient_int_LDADD = $(TEST_INT_LIBS)
 test_integration_get_capability_handles_transient_int_SOURCES = \
     test/integration/main.c test/integration/get-capability-handles-transient.int.c
 
-test_integration_session_load_from_open_connection_int_LDADD   = $(libtest) $(libtcti_tabrmd) \
-    $(GLIB_LIBS)
+test_integration_session_load_from_open_connection_int_LDADD = $(TEST_INT_LIBS)
 test_integration_session_load_from_open_connection_int_SOURCES = \
     test/integration/session-load-from-open-connection.int.c
 
-test_integration_session_load_from_closed_connection_int_LDADD   = $(libtest) $(libtcti_tabrmd) \
-    $(GLIB_LIBS)
+test_integration_session_load_from_closed_connection_int_LDADD = $(TEST_INT_LIBS)
 test_integration_session_load_from_closed_connection_int_SOURCES = \
     test/integration/session-load-from-closed-connection.int.c
 
-test_integration_session_load_from_closed_connections_lru_int_LDADD   = $(libtest) $(libtcti_tabrmd) \
-    $(GLIB_LIBS)
+test_integration_session_load_from_closed_connections_lru_int_LDADD = $(TEST_INT_LIBS)
 test_integration_session_load_from_closed_connections_lru_int_SOURCES = \
     test/integration/session-load-from-closed-connections-lru.int.c
 
-test_integration_start_auth_session_int_LDADD   = $(libtest) $(libtcti_tabrmd) $(GLIB_LIBS)
+test_integration_start_auth_session_int_LDADD = $(TEST_INT_LIBS)
 test_integration_start_auth_session_int_SOURCES = test/integration/main.c test/integration/start-auth-session.int.c
 
-test_integration_tcti_cancel_int_LDADD   = $(libtest) $(libtcti_tabrmd) $(GLIB_LIBS) $(GOBJECT_LIBS)
+test_integration_tcti_cancel_int_LDADD = $(TEST_INT_LIBS)
 test_integration_tcti_cancel_int_SOURCES = test/integration/main.c test/integration/tcti-cancel.int.c
 
-test_integration_tcti_connect_multiple_int_LDADD   = $(libtest) $(libtcti_tabrmd) $(GLIB_LIBS) $(GOBJECT_LIBS)
+test_integration_tcti_connect_multiple_int_LDADD = $(TEST_INT_LIBS)
 test_integration_tcti_connect_multiple_int_SOURCES = test/integration/tcti-connect-multiple.int.c
 
-test_integration_tcti_sessions_max_int_LDADD   = $(libtest) $(libtcti_tabrmd) $(GLIB_LIBS) $(GOBJECT_LIBS)
+test_integration_tcti_sessions_max_int_LDADD = $(TEST_INT_LIBS)
 test_integration_tcti_sessions_max_int_SOURCES = test/integration/tcti-sessions-max.int.c
 
-test_integration_tcti_set_locality_int_LDADD   = $(libtest) $(libtcti_tabrmd) $(GLIB_LIBS) $(GOBJECT_LIBS)
+test_integration_tcti_set_locality_int_LDADD  = $(TEST_INT_LIBS)
 test_integration_tcti_set_locality_int_SOURCES = test/integration/main.c test/integration/tcti-set-locality.int.c
 
-test_integration_hash_sequence_int_LDADD   = $(libtest) $(libtcti_tabrmd) $(GLIB_LIBS) $(GOBJECT_LIBS)
+test_integration_hash_sequence_int_LDADD = $(TEST_INT_LIBS)
 test_integration_hash_sequence_int_SOURCES = test/integration/main.c test/integration/hash-sequence.int.c
 
-test_integration_not_enough_handles_for_command_int_LDADD   = $(libtest) $(libtcti_tabrmd) $(GLIB_LIBS) $(GOBJECT_LIBS)
+test_integration_not_enough_handles_for_command_int_LDADD = $(TEST_INT_LIBS)
 test_integration_not_enough_handles_for_command_int_SOURCES = test/integration/main.c test/integration/not-enough-handles-for-command.int.c
 
-test_integration_password_authorization_int_LDADD   = $(libtest) $(libtcti_tabrmd) $(GLIB_LIBS) $(GOBJECT_LIBS)
+test_integration_password_authorization_int_LDADD = $(TEST_INT_LIBS)
 test_integration_password_authorization_int_SOURCES = test/integration/main.c test/integration/password-authorization.int.c
 
-test_integration_manage_transient_keys_int_LDADD   = $(libtest) $(libtcti_tabrmd) \
-    $(GLIB_LIBS) $(GOBJECT_LIBS) $(SAPI_LIBS)
+test_integration_manage_transient_keys_int_LDADD = $(TEST_INT_LIBS)
 test_integration_manage_transient_keys_int_SOURCES = test/integration/main.c test/integration/manage-transient-keys.int.c
 
-test_integration_tpm2_command_flush_no_handle_int_LDADD   = $(libtest) \
-    $(libtcti_tabrmd) $(GLIB_LIBS) $(GOBJECT_LIBS)
+test_integration_tpm2_command_flush_no_handle_int_LDADD = $(TEST_INT_LIBS)
 test_integration_tpm2_command_flush_no_handle_int_SOURCES = \
     test/integration/main.c test/integration/tpm2-command-flush-no-handle.int.c
 
-test_integration_util_buf_max_upper_bound_int_LDADD   = $(libtest) \
-    $(libtcti_tabrmd) $(GLIB_LIBS) $(GOBJECT_LIBS)
+test_integration_util_buf_max_upper_bound_int_LDADD = $(TEST_INT_LIBS)
 test_integration_util_buf_max_upper_bound_int_SOURCES = \
     test/integration/main.c test/integration/util-buf-max-upper-bound.int.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -103,8 +103,8 @@ libutil        = src/libutil.la
 lib_LTLIBRARIES = src/libtcti-tabrmd.la
 noinst_LTLIBRARIES = \
     $(libtcti_echo) \
-    $(libutil) \
-    $(libtest)
+    $(libtest) \
+    $(libutil)
 man3_MANS = man/man3/tss2_tcti_tabrmd_init.3
 man7_MANS = man/man7/tcti-tabrmd.7
 man8_MANS = man/man8/tpm2-abrmd.8
@@ -235,6 +235,8 @@ src_libutil_la_SOURCES = \
     src/tcti.h \
     src/tcti-dynamic.c \
     src/tcti-dynamic.h \
+    src/tcti-util.c \
+    src/tcti-util.h \
     src/thread.c \
     src/thread.h \
     src/tpm2-command.c \
@@ -246,7 +248,8 @@ src_libutil_la_SOURCES = \
     src/util.c \
     src/util.h
 
-test_integration_libtest_la_LIBADD  = $(SAPI_LIBS) $(TCTI_SOCKET_LIBS) $(TCTI_DEVICE_LIBS) $(GLIB_LIBS)
+test_integration_libtest_la_LIBADD  = $(SAPI_LIBS) $(TCTI_SOCKET_LIBS) \
+    $(TCTI_DEVICE_LIBS) $(GLIB_LIBS)
 test_integration_libtest_la_SOURCES = \
     test/integration/common.c \
     test/integration/common.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,6 @@ tests_integration = \
     test/integration/session-load-from-open-connection.int \
     test/integration/start-auth-session.int \
     test/integration/tcti-cancel.int \
-    test/integration/tcti-connect-multiple.int \
     test/integration/tcti-sessions-max.int \
     test/integration/tcti-set-locality.int \
     test/integration/hash-sequence.int \
@@ -65,8 +64,10 @@ tests_integration = \
     test/integration/tpm2-command-flush-no-handle.int \
     test/integration/util-buf-max-upper-bound.int
 
+tests_integration_nohw = test/integration/tcti-connect-multiple.int
+
 if SIMULATOR_BIN
-TESTS_INTEGRATION = $(tests_integration)
+TESTS_INTEGRATION = $(tests_integration) $(tests_integration_nohw)
 endif
 
 if HWTPM

--- a/configure.ac
+++ b/configure.ac
@@ -67,28 +67,6 @@ AC_DEFUN([MY_ARG_WITH],
                       [use_[]$1=$withval],
                       [use_[]$1=$2])
          ])
-#
-# TCTIs
-#
-MY_ARG_WITH([tcti_device], [yes])
-AS_IF([test "x$use_tcti_device" != xno],
-      [PKG_CHECK_MODULES([TCTI_DEVICE],
-                         [tcti-device],
-                         [AC_DEFINE([HAVE_TCTI_DEVICE],
-                                    [1],
-                                    [device TCTI is available])])])
-AM_CONDITIONAL([TCTI_DEVICE], [test "x$use_tcti_device" != xno])
-MY_ARG_WITH([tcti_socket], [yes])
-AS_IF([test "x$use_tcti_socket" != xno],
-      [PKG_CHECK_MODULES([TCTI_SOCKET],
-                         [tcti-socket],
-                         [AC_DEFINE([HAVE_TCTI_SOCKET],
-                                    [1],
-                                    [socket TCTI is available])])])
-AM_CONDITIONAL([TCTI_SOCKET], [test "x$use_tcti_socket" != xno])
-AS_IF([test "x$use_tcti_device" == xno -a \
-            "x$use_tcti_socket" == xno],
-      [AC_MSG_ERROR([At least one TCTI must be enabled.])])
 
 #
 # systemd

--- a/src/tcti-util.c
+++ b/src/tcti-util.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2018, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <dlfcn.h>
+#include <glib.h>
+#include <inttypes.h>
+#include <sapi/tpm20.h>
+
+#include "tabrmd.h"
+
+TSS2_RC
+tcti_util_discover_info (const char *filename,
+                         const TSS2_TCTI_INFO **info)
+{
+    TSS2_TCTI_INFO_FUNC info_func;
+    void *tcti_dl_handle;
+
+    g_debug ("%s", __func__);
+    tcti_dl_handle = dlopen (filename, RTLD_LAZY);
+    if (tcti_dl_handle == NULL) {
+        g_warning ("failed to dlopen file %s: %s", filename, dlerror ());
+        return TSS2_RESMGR_RC_BAD_VALUE;
+    }
+    info_func = dlsym (tcti_dl_handle, TSS2_TCTI_INFO_SYMBOL);
+    if (info_func == NULL) {
+        g_warning ("Failed to get reference to symbol: %s", dlerror ());
+#if !defined (DISABLE_DLCLOSE)
+        dlclose (tcti_dl_handle);
+#endif
+        return TSS2_RESMGR_RC_BAD_VALUE;
+    }
+    *info = info_func ();
+#if !defined (DISABLE_DLCLOSE)
+    dlclose (tcti_dl_handle);
+#endif
+    return TSS2_RC_SUCCESS;
+}
+TSS2_RC
+tcti_util_dynamic_init (const TSS2_TCTI_INFO *info,
+                        const char *conf,
+                        TSS2_TCTI_CONTEXT **context)
+{
+    TSS2_RC        rc       = TSS2_RC_SUCCESS;
+    size_t         ctx_size;
+
+    g_debug ("%s", __func__);
+    if (info == NULL || info->init == NULL) {
+        g_warning ("%s: TCTI_INFO structure or init function pointer is NULL, "
+                   "cannot initialize context.", __func__);
+        return TSS2_RESMGR_RC_BAD_VALUE;
+    }
+    rc = info->init (NULL, &ctx_size, NULL);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_warning ("failed to get size for device TCTI contexxt structure: "
+                   "0x%x", rc);
+        goto out;
+    }
+    *context = g_malloc0 (ctx_size);
+    if (*context == NULL) {
+        g_warning ("failed to allocate memory");
+        rc = TSS2_RESMGR_RC_INTERNAL_ERROR;
+        goto out;
+    }
+    rc = info->init (*context, &ctx_size, conf);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_warning ("failed to initialize device TCTI context: 0x%x", rc);
+        g_free (*context);
+        *context = NULL;
+    }
+out:
+    return rc;
+}

--- a/src/tcti-util.h
+++ b/src/tcti-util.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef TABRMD_TCTI_UTIL_H
+#define TABRMD_TCTI_UTIL_H
+
+TSS2_RC
+tcti_util_discover_info (const char *filename,
+                         const TSS2_TCTI_INFO **info);
+TSS2_RC
+tcti_util_dynamic_init (const TSS2_TCTI_INFO *info,
+                        const char *conf,
+                        TSS2_TCTI_CONTEXT **context);
+
+#endif /* TABRMD_TCTI_UTIL_H */

--- a/test/integration/main.c
+++ b/test/integration/main.c
@@ -46,15 +46,7 @@ main (int   argc,
     TSS2_RC rc;
     TSS2_SYS_CONTEXT *sapi_context;
     int ret;
-    test_opts_t opts = {
-        .tcti_type      = TCTI_DEFAULT,
-        .device_file    = DEVICE_PATH_DEFAULT,
-        .socket_address = HOSTNAME_DEFAULT,
-        .socket_port    = PORT_DEFAULT,
-        .tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT,
-        .tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT,
-        .tcti_retries    = TCTI_RETRIES_DEFAULT,
-    };
+    test_opts_t opts = TEST_OPTS_DEFAULT_INIT;
 
     get_test_opts_from_env (&opts);
     if (sanity_check_test_opts (&opts) != 0)

--- a/test/integration/session-load-from-closed-connection.int.c
+++ b/test/integration/session-load-from-closed-connection.int.c
@@ -58,15 +58,7 @@ main (int argc,
 		TSS2_SYS_CONTEXT *sapi_context;
 		TPMI_SH_AUTH_SESSION  session_handle = 0, session_handle_load = 0;
 		TPMS_CONTEXT          context = { 0, };
-		test_opts_t opts = {
-			.tcti_type      = TCTI_DEFAULT,
-			.device_file    = DEVICE_PATH_DEFAULT,
-			.socket_address = HOSTNAME_DEFAULT,
-			.socket_port    = PORT_DEFAULT,
-			.tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT,
-			.tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT,
-			.tcti_retries    = TCTI_RETRIES_DEFAULT,
-		};
+		test_opts_t opts = TEST_OPTS_DEFAULT_INIT;
 
 		get_test_opts_from_env (&opts);
 		if (sanity_check_test_opts (&opts) != 0)

--- a/test/integration/session-load-from-closed-connections-lru.int.c
+++ b/test/integration/session-load-from-closed-connections-lru.int.c
@@ -146,15 +146,7 @@ main (int argc,
 {
     TSS2_SYS_CONTEXT *sapi_context;
     test_data_t test_data [TEST_MAX_SESSIONS] = { 0 };
-    test_opts_t opts = {
-        .tcti_type      = TCTI_DEFAULT,
-        .device_file    = DEVICE_PATH_DEFAULT,
-        .socket_address = HOSTNAME_DEFAULT,
-        .socket_port    = PORT_DEFAULT,
-        .tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT,
-        .tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT,
-        .tcti_retries    = TCTI_RETRIES_DEFAULT,
-    };
+    test_opts_t opts = TEST_OPTS_DEFAULT_INIT;
     guint success_count;
 
     get_test_opts_from_env (&opts);

--- a/test/integration/session-load-from-open-connection.int.c
+++ b/test/integration/session-load-from-open-connection.int.c
@@ -49,15 +49,7 @@ main (int argc,
     TSS2_SYS_CONTEXT *sapi_context0, *sapi_context1;
     TPMI_SH_AUTH_SESSION  session_handle = 0, session_handle_load = 0;
     TPMS_CONTEXT          context = { 0, };
-    test_opts_t opts = {
-        .tcti_type      = TCTI_DEFAULT,
-        .device_file    = DEVICE_PATH_DEFAULT,
-        .socket_address = HOSTNAME_DEFAULT,
-        .socket_port    = PORT_DEFAULT,
-        .tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT,
-        .tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT,
-        .tcti_retries    = TCTI_RETRIES_DEFAULT,
-    };
+    test_opts_t opts = TEST_OPTS_DEFAULT_INIT;
 
     get_test_opts_from_env (&opts);
     if (sanity_check_test_opts (&opts) != 0)

--- a/test/integration/tcti-connect-multiple.int.c
+++ b/test/integration/tcti-connect-multiple.int.c
@@ -96,11 +96,7 @@ main (int   argc,
 {
     TSS2_RC rc;
     TSS2_TCTI_CONTEXT *tcti_context[CONNECTION_COUNT] = { 0 };
-    test_opts_t opts = {
-        .tcti_type      = TCTI_DEFAULT,
-        .tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT,
-        .tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT,
-    };
+    test_opts_t opts = TEST_OPTS_DEFAULT_INIT;
     /* This is a pre-canned TPM2 command buffer to invoke 'GetCapability' */
     uint8_t cmd_buf[] = {
         0x80, 0x01, 0x00, 0x00, 0x00, 0x16, 0x00, 0x00,

--- a/test/integration/tcti-connect-multiple.int.c
+++ b/test/integration/tcti-connect-multiple.int.c
@@ -113,9 +113,6 @@ main (int   argc,
     if (sanity_check_test_opts (&opts) != 0) {
         g_error ("option sanity test failed");
     }
-    if (opts.tcti_type != TABRMD_TCTI) {
-        g_error ("TCTI type is not TABRMD, abroting test");
-    }
     size_t i;
     for (i = 0; i < CONNECTION_COUNT; ++i) {
         rc = tcti_tabrmd_init (&tcti_context [i],

--- a/test/integration/test-options.c
+++ b/test/integration/test-options.c
@@ -31,66 +31,6 @@
 #include "test-options.h"
 #include "tcti-tabrmd.h"
 
-/*
- * A structure to map a string name to an element in the TCTI_TYPE
- * enumeration.
- */
-typedef struct {
-    char       *name;
-    TCTI_TYPE   type;
-} tcti_map_entry_t;
-/*
- * A table of tcti_map_entry_t structures. This is how we map a string
- * provided on the command line to the enumeration.
- */
-tcti_map_entry_t tcti_map_table[] = {
-#ifdef HAVE_TCTI_DEVICE
-    {
-        .name = "device",
-        .type = DEVICE_TCTI,
-    },
-#endif
-#ifdef HAVE_TCTI_SOCKET
-    {
-        .name = "socket",
-        .type = SOCKET_TCTI,
-    },
-#endif
-    {
-        .name = "tabrmd",
-        .type = TABRMD_TCTI,
-    },
-    {
-        .name = "unknown",
-        .type = UNKNOWN_TCTI,
-    },
-};
-/*
- * Convert from a string to an element in the TCTI_TYPE enumeration.
- * An unkonwn name / string will map to UNKNOWN_TCTI.
- */
-TCTI_TYPE
-tcti_type_from_name (char const *tcti_str)
-{
-    int i;
-    for (i = 0; i < N_TCTI - 1; ++i)
-        if (strcmp (tcti_str, tcti_map_table[i].name) == 0)
-            return tcti_map_table[i].type;
-    return UNKNOWN_TCTI;
-}
-/*
- * Convert from an element in the TCTI_TYPE enumeration to a string
- * representation.
- */
-char* const
-tcti_name_from_type (TCTI_TYPE tcti_type)
-{
-    int i;
-    for (i = 0; i < N_TCTI - 1; ++i)
-        if (tcti_type == tcti_map_table[i].type)
-            return tcti_map_table[i].name;
-    return NULL;
-}
 TCTI_TABRMD_DBUS_TYPE
 bus_type_from_str (const char *bus_type_str)
 {
@@ -122,44 +62,6 @@ bus_str_from_type (TCTI_TABRMD_DBUS_TYPE bus_type)
 int
 sanity_check_test_opts (test_opts_t  *opts)
 {
-    switch (opts->tcti_type) {
-#ifdef HAVE_TCTI_DEVICE
-    case DEVICE_TCTI:
-        if (opts->device_file == NULL) {
-            fprintf (stderr, "device-path is NULL, check env\n");
-            return 1;
-        }
-        break;
-#endif
-#ifdef HAVE_TCTI_SOCKET
-    case SOCKET_TCTI:
-        if (opts->socket_address == NULL || opts->socket_port == 0) {
-            fprintf (stderr,
-                     "socket_address or socket_port is NULL, check env\n");
-            return 1;
-        }
-        break;
-#endif
-    case TABRMD_TCTI:
-        switch (opts->tabrmd_bus_type) {
-        case TCTI_TABRMD_DBUS_TYPE_SYSTEM:
-        case TCTI_TABRMD_DBUS_TYPE_SESSION:
-            break;
-        default:
-            fprintf (stderr,
-                     "tabrmd_bus_type is 0, check env\n");
-            return 1;
-        }
-        if (opts->tabrmd_bus_name == NULL) {
-            fprintf (stderr,
-                     "tabrmd_bus_name is NULL, check env\n");
-            return 1;
-        }
-        break;
-    default:
-        fprintf (stderr, "unknown TCTI type, check env\n");
-        return 1;
-    }
     return 0;
 }
 
@@ -170,22 +72,16 @@ sanity_check_test_opts (test_opts_t  *opts)
 int
 get_test_opts_from_env (test_opts_t          *test_opts)
 {
-    char *env_str, *end_ptr;
+    char *env_str;
 
     if (test_opts == NULL)
         return 1;
-    env_str = getenv (ENV_TCTI_NAME);
+    env_str = getenv (ENV_TCTI);
     if (env_str != NULL)
-        test_opts->tcti_type = tcti_type_from_name (env_str);
-    env_str = getenv (ENV_DEVICE_FILE);
+        test_opts->tcti_filename = env_str;
+    env_str = getenv (ENV_TCTI_CONF);
     if (env_str != NULL)
-        test_opts->device_file = env_str;
-    env_str = getenv (ENV_SOCKET_ADDRESS);
-    if (env_str != NULL)
-        test_opts->socket_address = env_str;
-    env_str = getenv (ENV_SOCKET_PORT);
-    if (env_str != NULL)
-        test_opts->socket_port = strtol (env_str, &end_ptr, 10);
+        test_opts->tcti_conf = env_str;
     env_str = getenv (ENV_TABRMD_BUS_TYPE);
     if (env_str != NULL) {
         test_opts->tabrmd_bus_type = bus_type_from_str (env_str);
@@ -207,10 +103,8 @@ void
 dump_test_opts (test_opts_t *opts)
 {
     printf ("test_opts_t:\n");
-    printf ("  tcti_type:      %s\n", tcti_name_from_type (opts->tcti_type));
-    printf ("  device_file:    %s\n", opts->device_file);
-    printf ("  socket_address: %s\n", opts->socket_address);
-    printf ("  socket_port:    %d\n", opts->socket_port);
+    printf ("  tcti_filename:   %s\n", opts->tcti_filename);
+    printf ("  tcti_conf:       %s\n", opts->tcti_conf);
     printf ("  tabrmd_bus_type: %s\n", bus_str_from_type (opts->tabrmd_bus_type));
     printf ("  tabrmd_bus_name: %s\n", opts->tabrmd_bus_name);
     printf ("  retries:         %" PRIuMAX "\n", opts->tcti_retries);

--- a/test/integration/test-options.h
+++ b/test/integration/test-options.h
@@ -54,6 +54,16 @@
 #define ENV_TABRMD_BUS_NAME "TABRMD_TEST_BUS_NAME"
 #define ENV_TCTI_RETRIES    "TABRMD_TEST_TCTI_RETRIES"
 
+#define TEST_OPTS_DEFAULT_INIT { \
+    .tcti_type = TCTI_DEFAULT, \
+    .device_file = DEVICE_PATH_DEFAULT, \
+    .socket_address = HOSTNAME_DEFAULT, \
+    .socket_port    = PORT_DEFAULT, \
+    .tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT, \
+    .tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT, \
+    .tcti_retries    = TCTI_RETRIES_DEFAULT, \
+}
+
 typedef enum {
     UNKNOWN_TCTI,
 #ifdef HAVE_TCTI_DEVICE

--- a/test/integration/test-options.h
+++ b/test/integration/test-options.h
@@ -31,56 +31,27 @@
 #include "sapi/tpm20.h"
 #include "tcti-tabrmd.h"
 
-/* Default TCTI */
-#define TCTI_DEFAULT      TABRMD_TCTI
-#define TCTI_DEFAULT_STR  "tabrmd"
-
-/* Defaults for Device TCTI */
-#define DEVICE_PATH_DEFAULT "/dev/tpm0"
-
-/* Deafults for Socket TCTI connections */
-#define HOSTNAME_DEFAULT "127.0.0.1"
-#define PORT_DEFAULT     2321
-
 /* Default number of attempts to init selected TCTI */
 #define TCTI_RETRIES_DEFAULT 5
 
 /* environment variables holding TCTI config */
-#define ENV_TCTI_NAME      "TPM20TEST_TCTI_NAME"
-#define ENV_DEVICE_FILE    "TPM2OTEST_DEVICE_FILE"
-#define ENV_SOCKET_ADDRESS "TPM20TEST_SOCKET_ADDRESS"
-#define ENV_SOCKET_PORT    "TPM20TEST_SOCKET_PORT"
+#define ENV_TCTI      "TABRMD_TEST_TCTI"
+#define ENV_TCTI_CONF "TABRMD_TEST_TCTI_CONF"
 #define ENV_TABRMD_BUS_TYPE "TABRMD_TEST_BUS_TYPE"
 #define ENV_TABRMD_BUS_NAME "TABRMD_TEST_BUS_NAME"
 #define ENV_TCTI_RETRIES    "TABRMD_TEST_TCTI_RETRIES"
 
 #define TEST_OPTS_DEFAULT_INIT { \
-    .tcti_type = TCTI_DEFAULT, \
-    .device_file = DEVICE_PATH_DEFAULT, \
-    .socket_address = HOSTNAME_DEFAULT, \
-    .socket_port    = PORT_DEFAULT, \
+    .tcti_filename = NULL, \
+    .tcti_conf = NULL, \
     .tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT, \
     .tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT, \
-    .tcti_retries    = TCTI_RETRIES_DEFAULT, \
+    .tcti_retries = TCTI_RETRIES_DEFAULT, \
 }
 
-typedef enum {
-    UNKNOWN_TCTI,
-#ifdef HAVE_TCTI_DEVICE
-    DEVICE_TCTI,
-#endif
-#ifdef HAVE_TCTI_SOCKET
-    SOCKET_TCTI,
-#endif
-    TABRMD_TCTI,
-    N_TCTI,
-} TCTI_TYPE;
-
 typedef struct {
-    TCTI_TYPE tcti_type;
-    char     *device_file;
-    char     *socket_address;
-    uint16_t  socket_port;
+    const char *tcti_filename;
+    const char *tcti_conf;
     TCTI_TABRMD_DBUS_TYPE tabrmd_bus_type;
     const char *tabrmd_bus_name;
     uintmax_t   tcti_retries;
@@ -90,8 +61,6 @@ typedef struct {
 
 const char  *bus_name_from_type         (TCTI_TABRMD_DBUS_TYPE bus_type);
 TCTI_TABRMD_DBUS_TYPE bus_type_from_str (const char*           bus_type_str);
-char* const  tcti_name_from_type        (TCTI_TYPE             tcti_type);
-TCTI_TYPE    tcti_type_from_name        (char const           *tcti_str);
 int          get_test_opts_from_env     (test_opts_t          *opts);
 int          sanity_check_test_opts     (test_opts_t          *opts);
 void         dump_test_opts             (test_opts_t          *opts);


### PR DESCRIPTION
I've only ever had a reason to run the integration tests through a TCTI other than `tcti-tabrmd` a few times but it's useful functionality. This RP cleans out the remaining components that linked directly to `tcti-device` and `tcti-socket`. After all of this the integration tests should only link against `tcti-tabrmd` which is the default TCTI. Any other TCTI supporting dynamic loading (like the two we used to link against) can be used by way of the dynamic TCTI loading functions implemented in our local `libtcti-util.a`.

This PR also includes a few cleanup patches that had to go in before the dynamic TCTI stuff.