### PR TITLE
TctiDynamic: Fix bad default TCTI library string.

### DIFF
--- a/src/tcti-dynamic.h
+++ b/src/tcti-dynamic.h
@@ -34,7 +34,7 @@
 
 G_BEGIN_DECLS
 
-#define TCTI_DYNAMIC_DEFAULT_FILE_NAME "tcti-device.so"
+#define TCTI_DYNAMIC_DEFAULT_FILE_NAME "libtcti-device.so"
 #define TCTI_DYNAMIC_DEFAULT_CONF_STR  "/dev/tpm0"
 
 typedef struct _TctiDynamicClass {


### PR DESCRIPTION
This bug causes the daemon, when started without a `--tcti` option, to
fail to initialize a TCTI and thus fail to start.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>