### PR TITLE
D-Bus: install a service file to allow on-demand systemd unit activation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -142,6 +142,7 @@ EXTRA_DIST = \
     dist/tpm2-abrmd.preset \
     dist/tpm2-abrmd.service.in \
     dist/tpm-udev.rules \
+    dist/com.intel.tss2.Tabrmd.service \
     scripts/int-simulator-setup.sh \
     scripts/int-hardware-setup.sh \
     scripts/int-test-funcs.sh \
@@ -172,6 +173,8 @@ dbuspolicy_DATA  = dist/tpm2-abrmd.conf
 udevrules_DATA   = dist/tpm-udev.rules
 if HAVE_SYSTEMD
 systemdsystemunit_DATA = dist/tpm2-abrmd.service
+dbusservicedir   = $(datadir)/dbus-1/system-services
+dbusservice_DATA = dist/com.intel.tss2.Tabrmd.service
 endif # HAVE_SYSTEMD
 systemdpreset_DATA = dist/tpm2-abrmd.preset
 

--- a/dist/com.intel.tss2.Tabrmd.service
+++ b/dist/com.intel.tss2.Tabrmd.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=com.intel.tss2.Tabrmd
+Exec=/bin/false
+SystemdService=tpm2-abrmd.service


### PR DESCRIPTION
Maybe you'd like to add these bits. A D-Bus service file allows to start the daemon on demand without having to explicitly enable the system unit.