### PR TITLE
ci: Install libgcrypt development package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
       - dbus-x11
       - cmake
       - lcov
+      - libgcrypt20-dev
       - libglib2.0-dev
       - libdbus-1-dev
       - liburiparser-dev


### PR DESCRIPTION
This is a new dependency for the ESAPI library that's now in the
tpm2-tss repo.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>