### PR TITLE
dist: Add tpmrm to udev rule and allow tss group users to access the …

### DIFF
--- a/dist/tpm-udev.rules
+++ b/dist/tpm-udev.rules
@@ -1,2 +1,2 @@
 # tpm2-abrmd should be run as unprivileged tss user
-KERNEL=="tpm[0-9]*", MODE="0600", OWNER="tss", GROUP="tss"
+KERNEL=="tpmrm[0-9]*|tpm[0-9]*", MODE="0660", OWNER="tss", GROUP="tss"


### PR DESCRIPTION
…TPM2

The udev rule only takes into account the character devices that directly
exposes the TPM2, but no the ones exposed by the TPM zones infrastructure.

Also, it only allows the tss user to access the TPM2 and not the users in
the tss group, so change the permissions so users can also read and write.

Fixes: #334

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>