### PR TITLE
Clarify UID restriction to users tss and root. Fixes #342

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,6 +27,7 @@ https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm532.tar
 attention described below.
 
 # System User & Group
+`tpm2-abrmd` must run as user `tss` or `root`.
 As is common security practice we encourage *everyone* to run the `tpm2-abrmd`
 as an unprivileged user. This requires creating a user account and group to
 use for this purpose. Our current configuration assumes that the name for this
@@ -43,9 +44,12 @@ $ sudo useradd --system --user-group tss
 You may wish to further restrict this user account based on your needs. This
 topic however is beyond the scope of this document.
 
+To run tpm2-abrmd as root, which is not recommended, use the `--allow-root`
+option.
+
 # Obtaining the Source Code
 As is always the case, you should check for packages available through your
-Linux distro before you attepmt to download and build the tpm2-abrmd from
+Linux distro before you attempt to download and build the tpm2-abrmd from
 source code directly. If you need a newer version than provided by your
 Distro of choice then you should download our latest stable release here:
 https://github.com/01org/tpm2-abrmd/releases/latest.
@@ -96,7 +100,7 @@ all supported options.
 The `tpm2-abrmd` claims a name on the D-Bus system bus. This requires policy
 to allow the `tss` user account to claim this name. By default the build
 installs this configuration file to `${sysconfdir}/dbus-1/system.d`. We allow
-this to be overriden using the `--with-dbuspolicydir` option.
+this to be overridden using the `--with-dbuspolicydir` option.
 
 Using Debian (and it's various derivatives) as an example we can instruct the
 build to install the dbus policy configuration in the right location with the

--- a/src/ipc-frontend-dbus.c
+++ b/src/ipc-frontend-dbus.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -276,7 +276,7 @@ get_pid_from_dbus_invocation (GDBusProxy            *proxy,
     }
 }
 /*
- * Generate a random uint64 returned in the id out paramter.
+ * Generate a random uint64 returned in the id out parameter.
  * Mix this random ID with the PID from the caller. This is obtained
  * through the invocation parameter. Mix the two together using xor and
  * return the result through the id_pid_mix out parameter.
@@ -439,7 +439,7 @@ on_handle_create_connection (TctiTabrmd            *skeleton,
  * requesting that an outstanding TPM command should be canceled. It is
  * registered with the Tabrmd in response to acquiring a name
  * on the dbus (on_name_acquired). It does X things:
- * - Locate the Connection object associted with the 'id' parameter in
+ * - Locate the Connection object associated with the 'id' parameter in
  *   the ConnectionManager.
  * - If the connection has a command being processed by the tabrmd then it's
  *   removed from the processing queue.
@@ -622,7 +622,8 @@ on_name_lost (GDBusConnection *connection,
 
     if (self->dbus_name_acquired == FALSE) {
         g_critical ("Failed to acquire DBus name %s. UID %d must be "
-                    "allowed to \"own\" this name. Check DBus config.",
+                    "allowed to \"own\" this name. Check DBus config "
+                    "and check that this is running as user tss or root.",
                     name, getuid ());
     } else {
         self->dbus_name_acquired = FALSE;

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -94,7 +94,7 @@ static gboolean
 signal_handler (gpointer user_data)
 {
     g_info ("handling signal");
-    /* this is the only place the global poiner to the GMainLoop is accessed */
+    /* this is the only place the global pointer to the GMainLoop is accessed */
     main_loop_quit ((GMainLoop*)user_data);
 
     return G_SOURCE_CONTINUE;
@@ -111,7 +111,7 @@ on_ipc_frontend_disconnect (IpcFrontend *ipc_frontend,
  * This function initializes and configures all of the long-lived objects
  * in the tabrmd system. It is invoked on a thread separate from the main
  * thread as a way to get the main thread listening for connections on
- * DBus as quickly as possible. Any incomming DBus requests will block
+ * DBus as quickly as possible. Any incoming DBus requests will block
  * on the 'init_mutex' until this thread completes but they won't be
  * timing etc. This function does X things:
  * - Locks the init_mutex.
@@ -448,7 +448,7 @@ main (int argc, char *argv[])
     g_info ("tabrmd startup");
     parse_opts (argc, argv, &gmain_data.options);
     if (geteuid() == 0 && ! gmain_data.options.allow_root) {
-        g_print ("refusing to run as root. pass --allow-root if you know what you're doing.");
+        g_print ("Refusing to run as root. Pass --allow-root if you know what you are doing.\n");
         return 1;
     }
 

--- a/src/tcti-dynamic.c
+++ b/src/tcti-dynamic.c
@@ -100,7 +100,7 @@ tcti_dynamic_finalize (GObject *obj)
     TctiDynamic    *tcti_dynamic = TCTI_DYNAMIC (obj);
 
     if (tcti->tcti_context) {
-        tss2_tcti_finalize (tcti->tcti_context);
+        Tss2_Tcti_Finalize (tcti->tcti_context);
     }
     g_clear_pointer (&tcti->tcti_context, g_free);
 #if !defined (DISABLE_DLCLOSE)

--- a/src/tcti-echo.c
+++ b/src/tcti-echo.c
@@ -89,7 +89,7 @@ tcti_echo_finalize (GObject *obj)
     Tcti *tcti = TCTI (obj);
 
     if (tcti->tcti_context != NULL) {
-        tss2_tcti_finalize (tcti->tcti_context);
+        Tss2_Tcti_Finalize (tcti->tcti_context);
     }
     g_clear_pointer (&tcti->tcti_context, g_free);
     G_OBJECT_CLASS (tcti_echo_parent_class)->finalize (obj);

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -44,7 +44,7 @@
 static TSS2_RC
 tss2_tcti_tabrmd_transmit (TSS2_TCTI_CONTEXT *context,
                            size_t             size,
-                           uint8_t           *command)
+                           const uint8_t      *command)
 {
     ssize_t write_ret;
     TSS2_RC tss2_ret = TSS2_RC_SUCCESS;

--- a/src/tcti.c
+++ b/src/tcti.c
@@ -70,7 +70,7 @@ tcti_transmit (Tcti      *self,
                size_t     size,
                uint8_t   *command)
 {
-    return tss2_tcti_transmit (self->tcti_context,
+    return Tss2_Tcti_Transmit (self->tcti_context,
                                size,
                                command);
 }
@@ -80,7 +80,7 @@ tcti_receive (Tcti      *self,
               uint8_t   *response,
               int32_t    timeout)
 {
-    return tss2_tcti_receive (self->tcti_context,
+    return Tss2_Tcti_Receive (self->tcti_context,
                               size,
                               response,
                               timeout);
@@ -88,11 +88,11 @@ tcti_receive (Tcti      *self,
 TSS2_RC
 tcti_cancel (Tcti  *self)
 {
-    return tss2_tcti_cancel (self->tcti_context);
+    return Tss2_Tcti_Cancel (self->tcti_context);
 }
 TSS2_RC
 tcti_set_locality (Tcti     *self,
                    uint8_t   locality)
 {
-    return tss2_tcti_set_locality (self->tcti_context, locality);
+    return Tss2_Tcti_SetLocality (self->tcti_context, locality);
 }

--- a/src/tss2-tcti-echo.c
+++ b/src/tss2-tcti-echo.c
@@ -33,7 +33,7 @@
 TSS2_RC
 tss2_tcti_echo_transmit (TSS2_TCTI_CONTEXT *tcti_context,
                          size_t             size,
-                         uint8_t           *command)
+                         const uint8_t      *command)
 {
     TCTI_ECHO_CONTEXT *echo_context = (TCTI_ECHO_CONTEXT*)tcti_context;
 

--- a/test/access-broker_unit.c
+++ b/test/access-broker_unit.c
@@ -93,7 +93,7 @@ __wrap_Tss2_Sys_GetCapability (TSS2_SYS_CONTEXT         *sysContext,
 TSS2_RC
 __wrap_tcti_echo_transmit (TSS2_TCTI_CONTEXT *tcti_context,
                            size_t             size,
-                           uint8_t           *command)
+                           const uint8_t      *command)
 {
     TSS2_RC rc;
 

--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -174,7 +174,7 @@ sapi_teardown_full (TSS2_SYS_CONTEXT *sapi_context)
     Tss2_Sys_Finalize (sapi_context);
     free (sapi_context);
     if (tcti_context) {
-        tss2_tcti_finalize (tcti_context);
+        Tss2_Tcti_Finalize (tcti_context);
         free (tcti_context);
     }
 }

--- a/test/integration/not-enough-handles-for-command.int.c
+++ b/test/integration/not-enough-handles-for-command.int.c
@@ -59,12 +59,12 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
                  PRIx32, rc);
     }
 
-    rc = tss2_tcti_transmit (tcti_context, buf_size, cmd_buf);
+    rc = Tss2_Tcti_Transmit (tcti_context, buf_size, cmd_buf);
     if (rc != TSS2_RC_SUCCESS) {
         g_error ("Error transmitting cmd_buf: 0x%" PRIx32, rc);
     }
 
-    rc = tss2_tcti_receive (tcti_context,
+    rc = Tss2_Tcti_Receive (tcti_context,
                             &buf_size,
                             cmd_buf,
                             TSS2_TCTI_TIMEOUT_BLOCK);

--- a/test/integration/tcti-cancel.int.c
+++ b/test/integration/tcti-cancel.int.c
@@ -55,13 +55,13 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         return 1;
     }
     g_info ("sending command buffer");
-    rc = tss2_tcti_transmit (tcti_context, cmd_buffer_size, cmd_buffer);
+    rc = Tss2_Tcti_Transmit (tcti_context, cmd_buffer_size, cmd_buffer);
     if (rc != TSS2_RC_SUCCESS) {
         g_critical ("failed to send command");
         return 1;
     }
     g_info ("invoking tss2_tcti_tabrmd_cancel");
-    rc = tss2_tcti_cancel (tcti_context);
+    rc = Tss2_Tcti_Cancel (tcti_context);
     if (rc == TSS2_RESMGR_RC_NOT_IMPLEMENTED) {
         g_warning ("tss2_tcti_tabrmd_cancel failed as expected: 0x%" PRIx32,
                    rc);

--- a/test/integration/tcti-connect-multiple.int.c
+++ b/test/integration/tcti-connect-multiple.int.c
@@ -120,13 +120,13 @@ main (int   argc,
         }
     }
     for (i = 0; i < CONNECTION_COUNT; ++i) {
-        rc = tss2_tcti_transmit (tcti_context [i], sizeof (cmd_buf), cmd_buf);
+        rc = Tss2_Tcti_Transmit (tcti_context [i], sizeof (cmd_buf), cmd_buf);
         if (rc != TSS2_RC_SUCCESS) {
             g_error ("failed to transmit TPM command");
         }
     }
     for (i = 0; i < CONNECTION_COUNT; ++i) {
-        tss2_tcti_finalize (tcti_context [i]);
+        Tss2_Tcti_Finalize (tcti_context [i]);
         free (tcti_context [i]);
     }
 }

--- a/test/integration/tcti-set-locality.int.c
+++ b/test/integration/tcti-set-locality.int.c
@@ -49,7 +49,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         return 1;
     }
     g_info ("invoking tss2_tcti_tabrmd_set_locality");
-    rc = tss2_tcti_set_locality (tcti_context, 1);
+    rc = Tss2_Tcti_SetLocality (tcti_context, 1);
     if (rc == TSS2_RESMGR_RC_NOT_IMPLEMENTED) {
         g_info ("tss2_tcti_tabrmd_set_locality failed as expected: 0x%" PRIx32,
                 rc);

--- a/test/integration/tpm2-command-flush-no-handle.int.c
+++ b/test/integration/tpm2-command-flush-no-handle.int.c
@@ -58,11 +58,11 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
                  PRIx32, rc);
     }
 
-    rc = tss2_tcti_transmit (tcti_context, sizeof (cmd_buf), cmd_buf);
+    rc = Tss2_Tcti_Transmit (tcti_context, sizeof (cmd_buf), cmd_buf);
     if (rc != TSS2_RC_SUCCESS) {
         g_error ("Error transmitting cmd_buf: 0x%" PRIx32, rc);
     }
-    rc = tss2_tcti_receive (tcti_context,
+    rc = Tss2_Tcti_Receive (tcti_context,
                             &buf_size,
                             cmd_buf,
                             TSS2_TCTI_TIMEOUT_BLOCK);

--- a/test/integration/util-buf-max-upper-bound.int.c
+++ b/test/integration/util-buf-max-upper-bound.int.c
@@ -53,7 +53,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
                  PRIx32, rc);
     }
 
-    rc = tss2_tcti_transmit (tcti_context, sizeof (cmd_buf), cmd_buf);
+    rc = Tss2_Tcti_Transmit (tcti_context, sizeof (cmd_buf), cmd_buf);
     if (rc != TSS2_RC_SUCCESS) {
         g_error ("Error transmitting cmd_buf: 0x%" PRIx32, rc);
     }

--- a/test/tss2-tcti-echo_unit.c
+++ b/test/tss2-tcti-echo_unit.c
@@ -174,7 +174,7 @@ tss2_tcti_echo_init_teardown (void **state)
 {
     test_data_t *data = (test_data_t*)*state;
 
-    tss2_tcti_finalize (data->tcti_context);
+    Tss2_Tcti_Finalize (data->tcti_context);
     free (data->tcti_context);
     free (data);
 
@@ -192,7 +192,7 @@ tss2_tcti_echo_cancel_unit (void **state)
     test_data_t *data = (test_data_t*)*state;
     TSS2_RC rc;
 
-    rc = tss2_tcti_cancel (data->tcti_context);
+    rc = Tss2_Tcti_Cancel (data->tcti_context);
     assert_int_equal (rc, TSS2_TCTI_RC_NOT_IMPLEMENTED);
 }
 /**
@@ -209,7 +209,7 @@ tss2_tcti_echo_get_poll_handles_unit (void **state)
     TSS2_TCTI_POLL_HANDLE handles[3] = { 0, };
     size_t  num_handles = 3;
 
-    rc = tss2_tcti_get_poll_handles (data->tcti_context,
+    rc = Tss2_Tcti_GetPollHandles (data->tcti_context,
                                      handles,
                                      &num_handles);
     assert_int_equal (rc, TSS2_TCTI_RC_NOT_IMPLEMENTED);
@@ -226,7 +226,7 @@ tss2_tcti_echo_set_locality_unit (void **state)
     TSS2_RC rc;
     uint8_t locality = 0;
 
-    rc = tss2_tcti_set_locality (data->tcti_context, locality);
+    rc = Tss2_Tcti_SetLocality (data->tcti_context, locality);
     assert_int_equal (rc, TSS2_TCTI_RC_NOT_IMPLEMENTED);
 }
 /**
@@ -240,8 +240,8 @@ tss2_tcti_echo_transmit_null_context_unit (void **state)
 {
     TSS2_RC rc;
 
-    rc = tss2_tcti_transmit (NULL, 0, NULL);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
+    rc = Tss2_Tcti_Transmit (NULL, 0, NULL);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
 }
 /**
  * A test: Call transmit with a NULL command buffer. Ensure we get the
@@ -253,7 +253,7 @@ tss2_tcti_echo_transmit_null_command_unit (void **state)
     test_data_t *data = (test_data_t*)*state;
     TSS2_RC rc;
 
-    rc = tss2_tcti_transmit (data->tcti_context, 5, NULL);
+    rc = Tss2_Tcti_Transmit (data->tcti_context, 5, NULL);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_VALUE);
 }
 /**
@@ -267,7 +267,7 @@ tss2_tcti_echo_transmit_negative_size_unit (void **state)
     TSS2_RC rc;
     uint8_t buffer [TSS2_TCTI_ECHO_MAX_BUF] = { 0, };
 
-    rc = tss2_tcti_transmit (data->tcti_context, -1, buffer);
+    rc = Tss2_Tcti_Transmit (data->tcti_context, -1, buffer);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_VALUE);
 }
 /**
@@ -281,7 +281,7 @@ tss2_tcti_echo_transmit_size_gt_max_unit (void **state)
     TSS2_RC rc;
     uint8_t buffer [TSS2_TCTI_ECHO_MAX_BUF] = { 0, };
 
-    rc = tss2_tcti_transmit (data->tcti_context,
+    rc = Tss2_Tcti_Transmit (data->tcti_context,
                              TSS2_TCTI_ECHO_MAX_BUF + 1,
                              buffer);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_VALUE);
@@ -300,7 +300,7 @@ tss2_tcti_echo_transmit_bad_sequence_unit (void **state)
     TSS2_RC rc;
 
     echo_context->state = CAN_RECEIVE;
-    rc = tss2_tcti_transmit (data->tcti_context,
+    rc = Tss2_Tcti_Transmit (data->tcti_context,
                              TSS2_TCTI_ECHO_MAX_BUF,
                              buffer);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_SEQUENCE);
@@ -321,7 +321,7 @@ tss2_tcti_echo_transmit_success_unit (void **state)
     uint8_t buffer [TSS2_TCTI_ECHO_MAX_BUF] = { 0xde, 0xad, 0xbe, 0xef, 0x0 };
     TSS2_RC rc;
 
-    rc = tss2_tcti_transmit (data->tcti_context,
+    rc = Tss2_Tcti_Transmit (data->tcti_context,
                              TSS2_TCTI_ECHO_MAX_BUF,
                              buffer);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
@@ -340,8 +340,8 @@ tss2_tcti_echo_receive_null_context_unit (void **state)
 {
     TSS2_RC rc;
 
-    rc = tss2_tcti_receive (NULL, NULL, NULL, 0);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
+    rc = Tss2_Tcti_Receive (NULL, NULL, NULL, 0);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
 }
 /**
  * A test: Call receive with a NULL size. Ensure we get the right error
@@ -355,7 +355,7 @@ tss2_tcti_echo_receive_null_size_unit (void **state)
     TSS2_RC rc;
 
     echo_context->state = CAN_RECEIVE;
-    rc = tss2_tcti_receive (data->tcti_context, NULL, NULL, 0);
+    rc = Tss2_Tcti_Receive (data->tcti_context, NULL, NULL, 0);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_VALUE);
 }
 /**
@@ -376,7 +376,7 @@ tss2_tcti_echo_receive_insufficient_size_unit (void **state)
 
     echo_context->data_size = TSS2_TCTI_ECHO_MAX_BUF;
     echo_context->state = CAN_RECEIVE;
-    rc = tss2_tcti_receive (data->tcti_context,
+    rc = Tss2_Tcti_Receive (data->tcti_context,
                             &size,
                             NULL,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -396,7 +396,7 @@ tss2_tcti_echo_receive_null_response_unit (void **state)
     size_t size = TSS2_TCTI_ECHO_MAX_BUF;
 
     echo_context->state = CAN_RECEIVE;
-    rc = tss2_tcti_receive (data->tcti_context, &size, NULL, 0);
+    rc = Tss2_Tcti_Receive (data->tcti_context, &size, NULL, 0);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_VALUE);
 }
 /**
@@ -413,7 +413,7 @@ tss2_tcti_echo_receive_negative_timeout_unit (void **state)
     uint8_t buffer [TSS2_TCTI_ECHO_MAX_BUF] = { 0, };
 
     echo_context->state = CAN_RECEIVE;
-    rc = tss2_tcti_receive (data->tcti_context, &size, buffer, -99);
+    rc = Tss2_Tcti_Receive (data->tcti_context, &size, buffer, -99);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_VALUE);
 }
 /**
@@ -436,7 +436,7 @@ tss2_tcti_echo_receive_success_unit (void **state)
     echo_context->buf[2] = 0xbe;
     echo_context->buf[3] = 0xef;
 
-    rc = tss2_tcti_receive (data->tcti_context,
+    rc = Tss2_Tcti_Receive (data->tcti_context,
                             &size,
                             buffer,
                             TSS2_TCTI_TIMEOUT_BLOCK);

--- a/test/tss2-tcti-tabrmd_unit.c
+++ b/test/tss2-tcti-tabrmd_unit.c
@@ -417,7 +417,7 @@ tcti_tabrmd_teardown (void **state)
 {
     data_t *data = *state;
 
-    tss2_tcti_finalize (data->context);
+    Tss2_Tcti_Finalize (data->context);
     close (data->client_fd);
     close (data->server_fd);
     if (data->context)
@@ -476,40 +476,40 @@ tcti_tabrmd_transmit_null_context_test (void **state)
 {
     TSS2_RC rc;
 
-    rc = tss2_tcti_transmit (NULL, 5, NULL);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
+    rc = Tss2_Tcti_Transmit (NULL, 5, NULL);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
 }
 static void
 tcti_tabrmd_receive_null_context_test (void **state)
 {
     TSS2_RC rc;
 
-    rc = tss2_tcti_receive (NULL, NULL, NULL, TSS2_TCTI_TIMEOUT_BLOCK);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
+    rc = Tss2_Tcti_Receive (NULL, NULL, NULL, TSS2_TCTI_TIMEOUT_BLOCK);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
 }
 static void
 tcti_tabrmd_cancel_null_context_test (void **state)
 {
     TSS2_RC rc;
 
-    rc = tss2_tcti_cancel (NULL);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
+    rc = Tss2_Tcti_Cancel (NULL);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
 }
 static void
 tcti_tabrmd_get_poll_handles_null_context_test (void **state)
 {
     TSS2_RC rc;
 
-    rc = tss2_tcti_get_poll_handles (NULL, NULL, NULL);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
+    rc = Tss2_Tcti_GetPollHandles (NULL, NULL, NULL);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
 }
 static void
 tcti_tabrmd_set_locality_null_context_test (void **state)
 {
     TSS2_RC rc;
 
-    rc = tss2_tcti_set_locality (NULL, 5);
-    assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
+    rc = Tss2_Tcti_SetLocality (NULL, 5);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
 }
 /*
  * This test makes a single call to the transmit function in the the
@@ -533,7 +533,7 @@ tcti_tabrmd_transmit_success_test (void **state)
     TSS2_RC rc;
     ssize_t ret;
 
-    rc = tss2_tcti_transmit (data->context, size, command_in);
+    rc = Tss2_Tcti_Transmit (data->context, size, command_in);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     ret = read (data->server_fd, command_out, size);
     assert_int_equal (ret, size);
@@ -554,7 +554,7 @@ tcti_tabrmd_transmit_bad_magic_test (void **state)
     size_t size = 12;
 
     TSS2_TCTI_MAGIC (data->context) = 1;
-    rc = tss2_tcti_transmit (data->context, size, command);
+    rc = Tss2_Tcti_Transmit (data->context, size, command);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_TRANSMIT);
@@ -572,7 +572,7 @@ tcti_tabrmd_transmit_bad_version_test (void **state)
     size_t size = 12;
 
     TSS2_TCTI_VERSION (data->context) = -1;
-    rc = tss2_tcti_transmit (data->context, size, command);
+    rc = Tss2_Tcti_Transmit (data->context, size, command);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_TRANSMIT);
@@ -590,7 +590,7 @@ tcti_tabrmd_transmit_bad_sequence_receive_test (void **state)
     size_t size = 12;
 
     TSS2_TCTI_TABRMD_STATE (data->context) = TABRMD_STATE_RECEIVE;
-    rc = tss2_tcti_transmit (data->context, size, command);
+    rc = Tss2_Tcti_Transmit (data->context, size, command);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_SEQUENCE);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_RECEIVE);
@@ -608,7 +608,7 @@ tcti_tabrmd_transmit_bad_sequence_final_test (void **state)
     size_t size = 12;
 
     TSS2_TCTI_TABRMD_STATE (data->context) = TABRMD_STATE_FINAL;
-    rc = tss2_tcti_transmit (data->context, size, command);
+    rc = Tss2_Tcti_Transmit (data->context, size, command);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_SEQUENCE);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_FINAL);
@@ -709,7 +709,7 @@ tcti_tabrmd_receive_success_test (void **state)
     will_return (__wrap_read_data, command_in);
     will_return (__wrap_read_data, sizeof (command_in) - TPM_HEADER_SIZE);
     will_return (__wrap_read_data, 0);
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             command_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -750,7 +750,7 @@ tcti_tabrmd_receive_poll_eintr_test (void **state)
     will_return (__wrap_read_data, command_in);
     will_return (__wrap_read_data, sizeof (command_in));
     will_return (__wrap_read_data, 0);
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             command_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -777,7 +777,7 @@ tcti_tabrmd_receive_poll_fail_test (void **state)
     will_return (__wrap_poll, ENOMEM);
     will_return (__wrap_poll, -1);
 
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             command_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -801,7 +801,7 @@ tcti_tabrmd_receive_poll_timeout_test (void **state)
     will_return (__wrap_poll, 0);
     will_return (__wrap_poll, 0);
 
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             command_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -821,7 +821,7 @@ tcti_tabrmd_receive_bad_magic_test (void **state)
     size_t size = 12;
 
     TSS2_TCTI_MAGIC (data->context) = 1;
-    rc = tss2_tcti_receive (data->context, &size, buf, TSS2_TCTI_TIMEOUT_BLOCK);
+    rc = Tss2_Tcti_Receive (data->context, &size, buf, TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_RECEIVE);
@@ -839,7 +839,7 @@ tcti_tabrmd_receive_bad_version_test (void **state)
     size_t size = 12;
 
     TSS2_TCTI_VERSION (data->context) = -1;
-    rc = tss2_tcti_receive (data->context, &size, buf, TSS2_TCTI_TIMEOUT_BLOCK);
+    rc = Tss2_Tcti_Receive (data->context, &size, buf, TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_CONTEXT);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_RECEIVE);
@@ -857,7 +857,7 @@ tcti_tabrmd_receive_bad_sequence_transmit_test (void **state)
     size_t size = 12;
 
     TSS2_TCTI_TABRMD_STATE (data->context) = TABRMD_STATE_TRANSMIT;
-    rc = tss2_tcti_receive (data->context, &size, buf, TSS2_TCTI_TIMEOUT_BLOCK);
+    rc = Tss2_Tcti_Receive (data->context, &size, buf, TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_SEQUENCE);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_TRANSMIT);
@@ -875,7 +875,7 @@ tcti_tabrmd_receive_bad_sequence_final_test (void **state)
     size_t size = 12;
 
     TSS2_TCTI_TABRMD_STATE (data->context) = TABRMD_STATE_FINAL;
-    rc = tss2_tcti_receive (data->context, &size, buf, TSS2_TCTI_TIMEOUT_BLOCK);
+    rc = Tss2_Tcti_Receive (data->context, &size, buf, TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_SEQUENCE);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_FINAL);
@@ -899,7 +899,7 @@ tcti_tabrmd_receive_bad_timeout_test (void **state)
     uint8_t command_out [sizeof (command_in)] = { 0 };
     TSS2_RC rc;
 
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             command_out,
                             -2);
@@ -915,7 +915,7 @@ tcti_tabrmd_receive_null_size_test (void **state)
     uint8_t command_out [TPM_HEADER_SIZE] = { 0, };
     TSS2_RC rc;
 
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             NULL,
                             command_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -931,7 +931,7 @@ tcti_tabrmd_receive_null_response_size_nonzero_test (void **state)
     size_t size = 1;
     TSS2_RC rc;
 
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             NULL,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -949,7 +949,7 @@ tcti_tabrmd_receive_size_lt_header_test (void **state)
     size_t size = sizeof (response) - 1;
     TSS2_RC rc;
 
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             response,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -981,7 +981,7 @@ tcti_tabrmd_receive_size_lt_body_test (void **state)
     will_return (__wrap_read_data, TPM_HEADER_SIZE);
     will_return (__wrap_read_data, 0);
 
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             buffer_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -1014,7 +1014,7 @@ tcti_tabrmd_receive_error_first_read_test (void **state)
     will_return (__wrap_read_data, 0);
     will_return (__wrap_read_data, G_IO_ERROR_WOULD_BLOCK);
 
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             buffer_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -1046,7 +1046,7 @@ tcti_tabrmd_receive_malformed_header_test (void **state)
     will_return (__wrap_read_data, TPM_HEADER_SIZE);
     will_return (__wrap_read_data, 0);
 
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             buffer_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -1084,7 +1084,7 @@ tcti_tabrmd_receive_two_reads_header_test (void **state)
     will_return (__wrap_read_data, TPM_HEADER_SIZE / 2);
     will_return (__wrap_read_data, G_IO_ERROR_WOULD_BLOCK);
 
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             buffer_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -1100,7 +1100,7 @@ tcti_tabrmd_receive_two_reads_header_test (void **state)
     will_return (__wrap_read_data, TPM_HEADER_SIZE / 2);
     will_return (__wrap_read_data, 0);
 
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             buffer_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -1133,7 +1133,7 @@ tcti_tabrmd_receive_get_size_test (void **state)
     will_return (__wrap_read_data, TPM_HEADER_SIZE);
     will_return (__wrap_read_data, 0);
 
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             NULL,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -1167,7 +1167,7 @@ tcti_tabrmd_receive_get_size_and_body_test (void **state)
     will_return (__wrap_read_data, TPM_HEADER_SIZE);
     will_return (__wrap_read_data, 0);
 
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             NULL,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -1184,7 +1184,7 @@ tcti_tabrmd_receive_get_size_and_body_test (void **state)
     will_return (__wrap_read_data, 0);
 
     size = sizeof (buffer_in) + 1;
-    rc = tss2_tcti_receive (data->context,
+    rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             buffer_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
@@ -1207,7 +1207,7 @@ tcti_tabrmd_cancel_test (void **state)
 
     will_return (__wrap_tcti_tabrmd_call_cancel_sync, TSS2_RC_SUCCESS);
     will_return (__wrap_tcti_tabrmd_call_cancel_sync, TRUE);
-    rc = tss2_tcti_cancel (data->context);
+    rc = Tss2_Tcti_Cancel (data->context);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_RECEIVE);
@@ -1223,7 +1223,7 @@ tcti_tabrmd_cancel_bad_sequence_test (void **state)
     TSS2_RC rc;
 
     TSS2_TCTI_TABRMD_STATE (data->context) = TABRMD_STATE_TRANSMIT;
-    rc = tss2_tcti_cancel (data->context);
+    rc = Tss2_Tcti_Cancel (data->context);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_SEQUENCE);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_TRANSMIT);
@@ -1238,7 +1238,7 @@ tcti_tabrmd_get_poll_handles_all_null_test (void **state)
     data_t *data = *state;
     TSS2_RC rc;
 
-    rc = tss2_tcti_get_poll_handles (data->context, NULL, NULL);
+    rc = Tss2_Tcti_GetPollHandles (data->context, NULL, NULL);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_REFERENCE);
 }
 /*
@@ -1253,7 +1253,7 @@ tcti_tabrmd_get_poll_handles_count_test (void **state)
     size_t num_handles = 0;
     TSS2_RC rc;
 
-    rc = tss2_tcti_get_poll_handles (data->context, NULL, &num_handles);
+    rc = Tss2_Tcti_GetPollHandles (data->context, NULL, &num_handles);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_true (num_handles > 0);
 }
@@ -1270,7 +1270,7 @@ tcti_tabrmd_get_poll_handles_bad_handles_count_test (void **state)
     size_t num_handles = 0;
     TSS2_RC rc;
 
-    rc = tss2_tcti_get_poll_handles (data->context, handles, &num_handles);
+    rc = Tss2_Tcti_GetPollHandles (data->context, handles, &num_handles);
     assert_int_equal (rc, TSS2_TCTI_RC_INSUFFICIENT_BUFFER);
 }
 /*
@@ -1288,7 +1288,7 @@ tcti_tabrmd_get_poll_handles_handles_test (void **state)
     TSS2_RC rc;
     int fd;
 
-    rc = tss2_tcti_get_poll_handles (data->context, handles, &num_handles);
+    rc = Tss2_Tcti_GetPollHandles (data->context, handles, &num_handles);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (1, num_handles);
     fd = TSS2_TCTI_TABRMD_FD (data->context);
@@ -1308,7 +1308,7 @@ tcti_tabrmd_set_locality_test (void **state)
 
     will_return (__wrap_tcti_tabrmd_call_set_locality_sync, TSS2_RC_SUCCESS);
     will_return (__wrap_tcti_tabrmd_call_set_locality_sync, TRUE);
-    rc = tss2_tcti_set_locality (data->context, locality);
+    rc = Tss2_Tcti_SetLocality (data->context, locality);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 }
 /*
@@ -1323,7 +1323,7 @@ tcti_tabrmd_set_locality_bad_sequence_test (void **state)
     TSS2_RC rc;
 
     TSS2_TCTI_TABRMD_STATE (data->context) = TABRMD_STATE_RECEIVE;
-    rc = tss2_tcti_set_locality (data->context, locality);
+    rc = Tss2_Tcti_SetLocality (data->context, locality);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_SEQUENCE);
 }
 int


### PR DESCRIPTION
Clarified error messages in tpm2-abrmd when
* not ran as user tss or root
* ran as root without --with-root

Testing
Ran as user tss, and as root with tpm2-abrmd --with-root
Negative tests: ran as root (without --with-root) and as non-root/non-tss user.
