### PR TITLE
tcti: Fix typos in Tss2_Tcti_ functions.

### DIFF
--- a/src/tcti-dynamic.c
+++ b/src/tcti-dynamic.c
@@ -100,7 +100,7 @@ tcti_dynamic_finalize (GObject *obj)
     TctiDynamic    *tcti_dynamic = TCTI_DYNAMIC (obj);
 
     if (tcti->tcti_context) {
-        tss2_tcti_finalize (tcti->tcti_context);
+        Tss2_Tcti_Finalize (tcti->tcti_context);
     }
     g_clear_pointer (&tcti->tcti_context, g_free);
 #if !defined (DISABLE_DLCLOSE)

--- a/src/tcti-echo.c
+++ b/src/tcti-echo.c
@@ -89,7 +89,7 @@ tcti_echo_finalize (GObject *obj)
     Tcti *tcti = TCTI (obj);
 
     if (tcti->tcti_context != NULL) {
-        tss2_tcti_finalize (tcti->tcti_context);
+        Tss2_Tcti_Finalize (tcti->tcti_context);
     }
     g_clear_pointer (&tcti->tcti_context, g_free);
     G_OBJECT_CLASS (tcti_echo_parent_class)->finalize (obj);

--- a/src/tcti.c
+++ b/src/tcti.c
@@ -70,7 +70,7 @@ tcti_transmit (Tcti      *self,
                size_t     size,
                uint8_t   *command)
 {
-    return tss2_tcti_transmit (self->tcti_context,
+    return Tss2_Tcti_Transmit (self->tcti_context,
                                size,
                                command);
 }
@@ -80,7 +80,7 @@ tcti_receive (Tcti      *self,
               uint8_t   *response,
               int32_t    timeout)
 {
-    return tss2_tcti_receive (self->tcti_context,
+    return Tss2_Tcti_Receive (self->tcti_context,
                               size,
                               response,
                               timeout);
@@ -88,11 +88,11 @@ tcti_receive (Tcti      *self,
 TSS2_RC
 tcti_cancel (Tcti  *self)
 {
-    return tss2_tcti_cancel (self->tcti_context);
+    return Tss2_Tcti_Cancel (self->tcti_context);
 }
 TSS2_RC
 tcti_set_locality (Tcti     *self,
                    uint8_t   locality)
 {
-    return tss2_tcti_set_locality (self->tcti_context, locality);
+    return Tss2_Tcti_SetLocality (self->tcti_context, locality);
 }

--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -174,7 +174,7 @@ sapi_teardown_full (TSS2_SYS_CONTEXT *sapi_context)
     Tss2_Sys_Finalize (sapi_context);
     free (sapi_context);
     if (tcti_context) {
-        tss2_tcti_finalize (tcti_context);
+        Tss2_Tcti_Finalize (tcti_context);
         free (tcti_context);
     }
 }


### PR DESCRIPTION
Without this patch build fails with 'implicit declaration of function'.

* src/tcti-dynamic.c (tcti_dynamic_finalize): Replace
  tss2_tcti_finalize with Tss2_Tcti_Finalize.
* src/tcti-echo.c (tcti_echo_finalize): Replace tss2_tcti_finalize
  with Tss2_Tcti_Finalize.
* src/tcti.c (tcti_transmit): Replace tss2_tcti_transmit with
  Tss2_Tcti_Transmit.
  (tcti_receive): Replace tss2_tcti_receive with Tss2_Tcti_Receive.
  (tcti_cancel): Replace tss2_tcti_cancel with Tss2_Tcti_Cancel.
  (tcti_set_locality): Replace tss2_tcti_set_locality with
  Tss2_Tcti_SetLocality.
* test/integration/context-util.c (sapi_teardown_full): Replace
  tss2_tcti_finalize with Tss2_Tcti_Finalize.

Signed-off-by: Manolis Ragkousis <manolis837@gmail.com>