### PR TITLE
update YES/NO references

### DIFF
--- a/src/resource-manager.c
+++ b/src/resource-manager.c
@@ -27,6 +27,8 @@
 #include <errno.h>
 #include <inttypes.h>
 
+#include <glib.h>
+
 #include "connection.h"
 #include "connection-manager.h"
 #include "control-message.h"
@@ -660,7 +662,7 @@ post_process_loaded_sessions (ResourceManager *resmgr,
 typedef struct {
     TPMS_CAPABILITY_DATA *cap_data;
     size_t                max_count;
-    TPMI_YES_NO           more_data;
+    gboolean              more_data;
     TPM2_HANDLE            start_handle;
 } vhandle_iterator_state_t;
 /*
@@ -687,7 +689,7 @@ vhandle_iterator_callback (gpointer entry,
              PRIu32, state->max_count, cap_data->data.handles.count);
     /* if we've collected max_count handles set 'more_data' and return */
     if (!(cap_data->data.handles.count < state->max_count)) {
-        state->more_data = YES;
+        state->more_data = TRUE;
         return;
     }
     cap_data->data.handles.handle [cap_data->data.handles.count] = vhandle;
@@ -717,10 +719,10 @@ handle_compare (gconstpointer a,
  * is the lowest numerical handle to return. The 'count' parameter is the
  * maximum number of handles to return in the capability data structure.
  * Returns:
- *   YES when more handles are present
- *   NO when there are no more handles
+ *   TRUE when more handles are present
+ *   FALSE when there are no more handles
  */
-TPMI_YES_NO
+gboolean
 get_cap_handles (HandleMap            *map,
                  TPM2_HANDLE            prop,
                  UINT32                count,
@@ -730,7 +732,7 @@ get_cap_handles (HandleMap            *map,
     vhandle_iterator_state_t state = {
         .cap_data     = cap_data,
         .max_count    = count,
-        .more_data    = NO,
+        .more_data    = FALSE,
         .start_handle = prop,
     };
 
@@ -823,7 +825,7 @@ get_cap_handles_response (Tpm2Command *command,
     TPM2_HT   handle_type = prop >> TPM2_HR_SHIFT;
     HandleMap *map;
     TPMS_CAPABILITY_DATA cap_data = { .capability = cap };
-    TPMI_YES_NO more_data = NO;
+    gboolean more_data = FALSE;
     uint8_t *resp_buf;
     Tpm2Response *response = NULL;
 

--- a/test/integration/get-capability-handles-transient.int.c
+++ b/test/integration/get-capability-handles-transient.int.c
@@ -88,7 +88,7 @@ get_transient_handles (TSS2_SYS_CONTEXT *sapi_context,
                        size_t           *handle_count)
 {
     TSS2_RC              rc          = TSS2_RC_SUCCESS;
-    TPMI_YES_NO          more_data   = NO;
+    TPMI_YES_NO          more_data   = 0;
     TPMS_CAPABILITY_DATA cap_data    = { 0, };
     size_t               handles_left = *handle_count;
     size_t               handles_got = 0;
@@ -124,8 +124,8 @@ get_transient_handles (TSS2_SYS_CONTEXT *sapi_context,
         }
         handles_got += cap_data.data.handles.count;
         handles_left -= handles_got;
-        more_data == YES ? g_print ("more data\n") : g_print ("no more data\n");
-    } while (more_data == YES);
+        more_data == 1 ? g_print ("more data\n") : g_print ("no more data\n");
+    } while (more_data == 1);
 
     *handle_count = handles_got + 1;
 
@@ -141,7 +141,7 @@ get_cap_trans_dump (TSS2_SYS_CONTEXT *sapi_context,
                     size_t count)
 {
     TSS2_RC              rc          = TSS2_RC_SUCCESS;
-    TPMI_YES_NO          more_data   = NO;
+    TPMI_YES_NO          more_data   = 0;
     TPMS_CAPABILITY_DATA cap_data    = { 0, };
     TPM2_HANDLE           last_handle = TPM2_TRANSIENT_FIRST;
 
@@ -170,8 +170,8 @@ get_cap_trans_dump (TSS2_SYS_CONTEXT *sapi_context,
             /* add one to last handle to get the next handle */
             last_handle = cap_data.data.handles.handle [i] + 1;
         }
-        more_data == YES ? g_print ("more data\n") : g_print ("no more data\n");
-    } while (more_data == YES);
+        more_data == 1 ? g_print ("more data\n") : g_print ("no more data\n");
+    } while (more_data == 1);
 
     return TSS2_RC_SUCCESS;
 }

--- a/test/integration/start-auth-session.int.c
+++ b/test/integration/start-auth-session.int.c
@@ -66,7 +66,7 @@ handles_count (TSS2_SYS_CONTEXT *sapi_context,
 {
     TSS2_RC              rc         = TSS2_RC_SUCCESS;
     TPM2_CAP              capability = TPM2_CAP_HANDLES;
-    TPMI_YES_NO          more_data  = NO;
+    TPMI_YES_NO          more_data  = 0;
     TPMS_CAPABILITY_DATA cap_data   = { 0, };
 
     rc = Tss2_Sys_GetCapability (sapi_context,
@@ -80,7 +80,7 @@ handles_count (TSS2_SYS_CONTEXT *sapi_context,
     if (rc != TSS2_RC_SUCCESS) {
         g_error ("error getting capability: 0x%" PRIx32, rc);
     }
-    if (more_data == YES) {
+    if (more_data == 1) {
         g_warning ("got 'more_data' from query on loaded sessions");
     }
     *count = cap_data.data.handles.count;
@@ -97,7 +97,7 @@ prettyprint_getcap_handles (TSS2_SYS_CONTEXT *sapi_context,
 {
     TSS2_RC              rc         = TSS2_RC_SUCCESS;
     TPM2_CAP              capability = TPM2_CAP_HANDLES;
-    TPMI_YES_NO          more_data  = NO;
+    TPMI_YES_NO          more_data  = 0;
     TPMS_CAPABILITY_DATA cap_data   = { 0, };
     size_t               count      = 100;
     size_t               i;
@@ -113,7 +113,7 @@ prettyprint_getcap_handles (TSS2_SYS_CONTEXT *sapi_context,
     if (rc != TSS2_RC_SUCCESS) {
         g_error ("error getting capability: 0x%" PRIx32, rc);
     }
-    if (more_data == YES) {
+    if (more_data == 1) {
         g_warning ("got 'more_data' from query on loaded sessions");
     }
     g_print ("GetCapability: cap: 0x%" PRIxHANDLE " prop: 0x%" PRIxHANDLE


### PR DESCRIPTION
tpm2-tss removed YES/NO macros.

Use a gboolean type and TRUE/FALSE to repleace them within the RM.
Update YES/NO to 1/0 in test cases that use that type directly
in SAPI calls.

Signed-off-by: William Roberts <william.c.roberts@intel.com>