### PR TITLE
tcti: Allow tss2_tcti_tabrmd_finalize() to be called twice

### DIFF
--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -293,6 +293,10 @@ tss2_tcti_tabrmd_finalize (TSS2_TCTI_CONTEXT *context)
         g_warning ("Invalid parameter");
         return;
     }
+    if (TABRMD_STATE_FINAL == TSS2_TCTI_TABRMD_STATE (context)) {
+        g_warning ("TSS2_TCTI_CONTEXT is already finalized");
+        return;
+    }
     TSS2_TCTI_TABRMD_STATE (context) = TABRMD_STATE_FINAL;
     g_clear_object (&TSS2_TCTI_TABRMD_SOCK_CONNECT (context));
     g_clear_object (&TSS2_TCTI_TABRMD_PROXY (context));


### PR DESCRIPTION
tss2_tcti_tabrmd_finalize() might get called more than once from the client-side when their implementation is buggy.
Add a defensive checking to prevent client application from crashing.