### PR TITLE
ci: Use mirrored cmocka and simulator tarballs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
   - tar xJf autoconf-archive-2017.09.28.tar.xz && pushd autoconf-archive-2017.09.28
   - ./configure --prefix=${PREFIX} && make && make install
   - popd # autoconf-archive
-  - wget https://cmocka.org/files/1.1/cmocka-1.1.1.tar.xz
+  - wget http://mirror.twobit.us/tpm2-deps/cmocka-1.1.1.tar.xz
   - tar -Jxvf cmocka-1.1.1.tar.xz
   - mkdir cmocka-1.1.1/build && pushd cmocka-1.1.1/build
   - cmake ../ -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_BUILD_TYPE=Release
@@ -66,7 +66,7 @@ install:
   - make -j$(nproc) install
   - popd # tpm2-tss
   - sed -i -e "s&\(\/usr\/lib\/lib.*\.la\)&${DESTDIR}\1&" ${DESTDIR}${PREFIX}/lib/*.la
-  - wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm974.tar.gz
+  - wget http://mirror.twobit.us/tpm2-deps/ibmtpm974.tar.gz
   - sha256sum ibmtpm974.tar.gz | grep -q ^8e45d86129a0adb95fee4cee51f4b1e5b2d81ed3e55af875df53f98f39eb7ad7
   - mkdir ibmtpm
   - tar axf ibmtpm974.tar.gz -C ibmtpm


### PR DESCRIPTION
sourceforge has been down on and off for a week. Cmocka.org had some
troubles last week too. Switching to a mirror to try to keep from having
any more down time in the future.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>