### PR TITLE
test: Ensure multiple calls to TCTI finalize function doesn't crash.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,7 @@ tests_integration = \
     test/integration/session-load-from-open-connection.int \
     test/integration/start-auth-session.int \
     test/integration/tcti-cancel.int \
+    test/integration/tcti-double-finalize.int \
     test/integration/tcti-sessions-max.int \
     test/integration/tcti-set-locality.int \
     test/integration/hash-sequence.int \
@@ -487,6 +488,10 @@ test_integration_start_auth_session_int_SOURCES = test/integration/main.c test/i
 
 test_integration_tcti_cancel_int_LDADD = $(TEST_INT_LIBS)
 test_integration_tcti_cancel_int_SOURCES = test/integration/main.c test/integration/tcti-cancel.int.c
+
+test_integration_tcti_double_finalize_int_LDADD = $(TEST_INT_LIBS)
+test_integration_tcti_double_finalize_int_SOURCES = test/integration/main.c \
+    test/integration/tcti-double-finalize.int.c
 
 test_integration_tcti_connect_multiple_int_LDADD = $(TEST_INT_LIBS)
 test_integration_tcti_connect_multiple_int_SOURCES = test/integration/tcti-connect-multiple.int.c

--- a/test/integration/tcti-double-finalize.int.c
+++ b/test/integration/tcti-double-finalize.int.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <glib.h>
+#include <inttypes.h>
+
+#include "tcti-tabrmd.h"
+
+/*
+ * This is a test program that exercises the TCTI cancel command.
+ */
+int
+test_invoke (TSS2_SYS_CONTEXT *sapi_context)
+{
+    TSS2_TCTI_CONTEXT *tcti_context = NULL;
+    TSS2_RC            rc = TSS2_RC_SUCCESS;
+
+    rc = Tss2_Sys_GetTctiContext (sapi_context, &tcti_context);
+    if (rc != TSS2_RC_SUCCESS || tcti_context == NULL) {
+        g_critical ("Tss2_Sys_GetTctiContext failed: 0x%" PRIx32, rc);
+        return 1;
+    }
+    Tss2_Tcti_Finalize (tcti_context);
+    Tss2_Tcti_Finalize (tcti_context);
+    return 0;
+}


### PR DESCRIPTION
We got a patch recently claiming that multiple calls to the TCTI
finalize function caused a crash. This doesn't seem to be the case since
this test passes but it's always best to have a test in place to ensure
this doesn't happen in the future.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>