### PR TITLE
Clarify UID Restriction to Users tss and root

### DIFF
--- a/src/ipc-frontend-dbus.c
+++ b/src/ipc-frontend-dbus.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -276,7 +276,7 @@ get_pid_from_dbus_invocation (GDBusProxy            *proxy,
     }
 }
 /*
- * Generate a random uint64 returned in the id out paramter.
+ * Generate a random uint64 returned in the id out parameter.
  * Mix this random ID with the PID from the caller. This is obtained
  * through the invocation parameter. Mix the two together using xor and
  * return the result through the id_pid_mix out parameter.
@@ -439,7 +439,7 @@ on_handle_create_connection (TctiTabrmd            *skeleton,
  * requesting that an outstanding TPM command should be canceled. It is
  * registered with the Tabrmd in response to acquiring a name
  * on the dbus (on_name_acquired). It does X things:
- * - Locate the Connection object associted with the 'id' parameter in
+ * - Locate the Connection object associated with the 'id' parameter in
  *   the ConnectionManager.
  * - If the connection has a command being processed by the tabrmd then it's
  *   removed from the processing queue.
@@ -622,7 +622,8 @@ on_name_lost (GDBusConnection *connection,
 
     if (self->dbus_name_acquired == FALSE) {
         g_critical ("Failed to acquire DBus name %s. UID %d must be "
-                    "allowed to \"own\" this name. Check DBus config.",
+                    "allowed to \"own\" this name. Check DBus config "
+                    "and check that this is running as user tss or root.",
                     name, getuid ());
     } else {
         self->dbus_name_acquired = FALSE;

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -94,7 +94,7 @@ static gboolean
 signal_handler (gpointer user_data)
 {
     g_info ("handling signal");
-    /* this is the only place the global poiner to the GMainLoop is accessed */
+    /* this is the only place the global pointer to the GMainLoop is accessed */
     main_loop_quit ((GMainLoop*)user_data);
 
     return G_SOURCE_CONTINUE;
@@ -111,7 +111,7 @@ on_ipc_frontend_disconnect (IpcFrontend *ipc_frontend,
  * This function initializes and configures all of the long-lived objects
  * in the tabrmd system. It is invoked on a thread separate from the main
  * thread as a way to get the main thread listening for connections on
- * DBus as quickly as possible. Any incomming DBus requests will block
+ * DBus as quickly as possible. Any incoming DBus requests will block
  * on the 'init_mutex' until this thread completes but they won't be
  * timing etc. This function does X things:
  * - Locks the init_mutex.
@@ -448,7 +448,7 @@ main (int argc, char *argv[])
     g_info ("tabrmd startup");
     parse_opts (argc, argv, &gmain_data.options);
     if (geteuid() == 0 && ! gmain_data.options.allow_root) {
-        g_print ("refusing to run as root. pass --allow-root if you know what you're doing.");
+        g_print ("Refusing to run as root. Pass --allow-root if you know what you are doing.\n");
         return 1;
     }
 


### PR DESCRIPTION
ipc-frontend-dbus.c: add to error message about running as user tss or root and fix spelling.
tabrmd.c: fix typos.

Fixes #342.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>