### PR TITLE
autotools: Include tpm2-abrmd preset template in distribution tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -139,7 +139,7 @@ EXTRA_DIST = \
     man/tpm2-abrmd.8.in \
     dist/tpm2-abrmd.conf \
     dist/tcti-tabrmd.pc.in \
-    dist/tpm2-abrmd.preset \
+    dist/tpm2-abrmd.preset.in \
     dist/tpm2-abrmd.service.in \
     dist/tpm-udev.rules \
     dist/com.intel.tss2.Tabrmd.service \


### PR DESCRIPTION
A generated tpm2-abrmd.preset file is included in the distribution tarball, so
there's no way to change the default preset policy by using a configure option.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>