### PR TITLE
man: tpm2-abrmd(8) Should Document Connection to a Simulator

### DIFF
--- a/man/tpm2-abrmd.8.in
+++ b/man/tpm2-abrmd.8.in
@@ -91,7 +91,9 @@ This is equivalent to:
 .br
 .B tpm2-abrmd --tcti="libtcti-device.so:/dev/tpm0"
 .TP
-Have daemon use socket tcti library 'libtcti-socket.so'
+Have daemon use socket tcti library 'libtcti-socket.so'.
+This connects to a TPM2 simulator via a TCP socket.
+.br
 .B tpm2-abrmd --tcti="socket"
 .br
 .B tpm2-abrmd --tcti="libtcti-socket.so"

--- a/man/tpm2-abrmd.8.in
+++ b/man/tpm2-abrmd.8.in
@@ -1,7 +1,7 @@
 .\" Process this file with
 .\" groff -man -Tascii foo.1
 .\"
-.TH TPM2-ABRMD 8 "February 2018" Intel "TPM2 Software Stack"
+.TH TPM2-ABRMD 8 "March 2018" Intel "TPM2 Software Stack"
 .SH NAME
 tpm2-abrmd \- TPM2 access broker and resource management daemon
 .SH SYNOPSIS
@@ -77,7 +77,7 @@ Connect daemon to the session dbus. This option overrides the default
 behavior.
 .TP
 \fB\-v,\ \-\-version\fR
-Disply version string.
+Display version string.
 .SH EXAMPLES
 .TP 3
 Execute daemon with default TCTI and options:


### PR DESCRIPTION
Man page tpm2-abrmd(8) should document the common option to connect
to the TPM2 simulator via a socket.

Fixes #364.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>