### PR TITLE
INSTALL.md: Document Running tpm2-abrmd with the Simulator

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -207,6 +207,13 @@ and executed. The test harness in the build system will run a `tpm_server` and
 `tpm2-abrmd` for each test executable. This allows the test harness to execute
 integration tests in parallel.
 
+**NOTE**: The `--with-simulatorbin` option does not change the default for
+tpm2-abrmd, which is to use TPM hardware.
+To run tpm2-abrmd with the simulator, use:
+```
+$ sudo -u tss /usr/local/sbin/tpm2-abrmd --tcti=socket
+```
+
 ### Run Integration Tests with hardware TPM2: `--test-hwtpm`
 Once you have a TPM hardware, configure the `./configure` script through the
 `--test-hwtpm` option:


### PR DESCRIPTION
Add text explaining that the `configure --with-simulatorbin` option,
does not change the tpm2-abrmd hardware TPM default.
Document how to run tpm2-abrmd with the simulator.

Fixes #366.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>