### PR TITLE
autotools: Include tpm2-abrmd preset template in distribution tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -139,7 +139,7 @@ EXTRA_DIST = \
     man/tpm2-abrmd.8.in \
     dist/tpm2-abrmd.conf \
     dist/tcti-tabrmd.pc.in \
-    dist/tpm2-abrmd.preset \
+    dist/tpm2-abrmd.preset.in \
     dist/tpm2-abrmd.service.in \
     dist/tpm-udev.rules \
     dist/com.intel.tss2.Tabrmd.service \
@@ -161,6 +161,7 @@ CLEANFILES = \
     src/tabrmd-generated.c \
     src/tabrmd-generated.h \
     $(pkgconfig_DATA) \
+    $(systemdpreset_DATA) \
     $(systemdsystemunit_DATA) \
     test/integration/*.log \
     _tabrmd.log
@@ -172,11 +173,11 @@ pkgconfig_DATA   = dist/tcti-tabrmd.pc
 dbuspolicy_DATA  = dist/tpm2-abrmd.conf
 udevrules_DATA   = dist/tpm-udev.rules
 if HAVE_SYSTEMD
+systemdpreset_DATA = dist/tpm2-abrmd.preset
 systemdsystemunit_DATA = dist/tpm2-abrmd.service
 dbusservicedir   = $(datadir)/dbus-1/system-services
 dbusservice_DATA = dist/com.intel.tss2.Tabrmd.service
 endif # HAVE_SYSTEMD
-systemdpreset_DATA = dist/tpm2-abrmd.preset
 
 @CODE_COVERAGE_RULES@
 @VALGRIND_CHECK_RULES@


### PR DESCRIPTION
A generated tpm2-abrmd.preset file is included in the distribution tarball, so
there's no way to change the default preset policy by using a configure option.
This commit causes the build to distribute the template file so that
builds from source will generate the final preset file with data from
the configure script. Additionally, the definition of the
systemdpreset_DATA variable is now conditionally defined alongside the
other systemd stuff.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>