### PR TITLE
INSTALL.md: Fix Spelling Errors

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,7 +45,7 @@ topic however is beyond the scope of this document.
 
 # Obtaining the Source Code
 As is always the case, you should check for packages available through your
-Linux distro before you attepmt to download and build the tpm2-abrmd from
+Linux distro before you attempt to download and build the tpm2-abrmd from
 source code directly. If you need a newer version than provided by your
 Distro of choice then you should download our latest stable release here:
 https://github.com/01org/tpm2-abrmd/releases/latest.
@@ -96,7 +96,7 @@ all supported options.
 The `tpm2-abrmd` claims a name on the D-Bus system bus. This requires policy
 to allow the `tss` user account to claim this name. By default the build
 installs this configuration file to `${sysconfdir}/dbus-1/system.d`. We allow
-this to be overriden using the `--with-dbuspolicydir` option.
+this to be overridden using the `--with-dbuspolicydir` option.
 
 Using Debian (and it's various derivatives) as an example we can instruct the
 build to install the dbus policy configuration in the right location with the


### PR DESCRIPTION
Fix misspelled words in INSTALL.md: attepmt and overriden.

Fixes #374.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>