### PR TITLE
tpm2-abrmd.service: Remove Unused EnvironmentFile Option

### DIFF
--- a/dist/tpm2-abrmd.service.in
+++ b/dist/tpm2-abrmd.service.in
@@ -1,4 +1,3 @@
-# copy this file into /etc/systemd/system
 [Unit]
 Description=TPM2 Access Broker and Resource Management Daemon
 
@@ -6,7 +5,6 @@ Description=TPM2 Access Broker and Resource Management Daemon
 Type=dbus
 Restart=always
 RestartSec=5
-EnvironmentFile=-@sysconfdir@/default/tpm2-abrmd
 BusName=com.intel.tss2.Tabrmd
 StandardOutput=syslog
 ExecStart=@SBINDIR@/tpm2-abrmd


### PR DESCRIPTION
Remove the unused EnvironmentFile option which specifies a file
that is not delivered.

Fixes #381.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>