### PR TITLE
Remove use of tpm20.h and use the appropriate TSS2 headers.

### DIFF
--- a/src/access-broker.c
+++ b/src/access-broker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,6 +27,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include "tabrmd.h"
 

--- a/src/access-broker.h
+++ b/src/access-broker.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,7 +30,7 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <pthread.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tcti.h"
 #include "tpm2-response.h"

--- a/src/command-attrs.h
+++ b/src/command-attrs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,7 +32,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 G_BEGIN_DECLS
 

--- a/src/handle-map-entry.h
+++ b/src/handle-map-entry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@
 
 #include <glib.h>
 #include <glib-object.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 G_BEGIN_DECLS
 

--- a/src/handle-map.h
+++ b/src/handle-map.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,7 +30,7 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <pthread.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 #include "handle-map-entry.h"
 

--- a/src/include/tss2-tcti-tabrmd.h
+++ b/src/include/tss2-tcti-tabrmd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,6 @@
 extern "C" {
 #endif
 
-#include <tss2/tpm20.h>
 #include <tss2/tss2_tcti.h>
 
 #define TCTI_TABRMD_DBUS_INTERFACE_DEFAULT "com.intel.tss2.TctiTabrmd"

--- a/src/ipc-frontend.h
+++ b/src/ipc-frontend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,6 @@
 #ifndef IPC_FRONTEND_H
 #define IPC_FRONTEND_H
 
-#include <tss2/tpm20.h>
 #include <glib-object.h>
 
 #include "connection.h"

--- a/src/random.c
+++ b/src/random.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,8 +31,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
-
-#include <tss2/tpm20.h>
 
 #include "random.h"
 

--- a/src/resource-manager.h
+++ b/src/resource-manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,7 +30,7 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <pthread.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 #include "access-broker.h"
 #include "connection-manager.h"

--- a/src/session-entry.h
+++ b/src/session-entry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@
 
 #include <glib.h>
 #include <glib-object.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 #include "connection.h"
 #include "session-entry-state-enum.h"

--- a/src/session-list.h
+++ b/src/session-list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,7 +30,7 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <pthread.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 #include "connection.h"
 #include "session-entry.h"

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2018, Intel Corporation
+ * Copyright (c) 2017 - 2018 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,8 +33,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <tss2/tss2_tpm2_types.h>
 
-#include <tss2/tpm20.h>
 #include "tabrmd.h"
 #include "access-broker.h"
 #include "connection.h"

--- a/src/tabrmd.h
+++ b/src/tabrmd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,8 @@
 #define TSS2_TABD_H
 
 #include <gio/gio.h>
-#include <tss2/tpm20.h>
+
+#include <tss2/tss2_tpm2_types.h>
 
 #include "tss2-tcti-tabrmd.h"
 

--- a/src/tcti-dynamic.h
+++ b/src/tcti-dynamic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,8 +27,8 @@
 #ifndef TABD_TCTI_DYNAMIC_H
 #define TABD_TCTI_DYNAMIC_H
 
-#include <tss2/tpm20.h>
 #include <glib-object.h>
+#include <tss2/tss2_tcti.h>
 
 #include "tcti.h"
 

--- a/src/tcti-echo.h
+++ b/src/tcti-echo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,8 +27,8 @@
 #ifndef TCTI_ECHO_H
 #define TCTI_ECHO_H
 
-#include <tss2/tpm20.h>
 #include <glib-object.h>
+#include <tss2/tss2_tcti.h>
 
 #include "tcti.h"
 

--- a/src/tcti-tabrmd-priv.h
+++ b/src/tcti-tabrmd-priv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,8 +29,7 @@
 
 #include <glib.h>
 #include <pthread.h>
-
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tcti.h>
 
 #include "tabrmd-generated.h"
 #include "tpm2-header.h"

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,7 +33,7 @@
 #include <poll.h>
 #include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 #include "tabrmd.h"
 #include "tss2-tcti-tabrmd.h"

--- a/src/tcti-util.h
+++ b/src/tcti-util.h
@@ -27,7 +27,7 @@
 #ifndef TABRMD_TCTI_UTIL_H
 #define TABRMD_TCTI_UTIL_H
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tcti.h>
 
 TSS2_RC
 tcti_util_discover_info (const char *filename,

--- a/src/tcti.h
+++ b/src/tcti.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,8 +27,8 @@
 #ifndef TCTI_H
 #define TCTI_H
 
-#include <tss2/tpm20.h>
 #include <glib-object.h>
+#include <tss2/tss2_tcti.h>
 
 G_BEGIN_DECLS
 

--- a/src/tpm2-command.h
+++ b/src/tpm2-command.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 #define TPM2_COMMAND_H
 
 #include <glib-object.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 #include "connection.h"
 

--- a/src/tpm2-header.c
+++ b/src/tpm2-header.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,7 +24,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <tss2/tpm20.h>
+#include <endian.h>
+#include <tss2/tss2_tpm2_types.h>
 
 /**
  * Extract the 'tag' field from the tpm command header. This is a

--- a/src/tpm2-header.h
+++ b/src/tpm2-header.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 #define TPM2_HEADER_H
 
 #include <sys/types.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tcti.h>
 
 /* A convenience macro to get us the size of the TPM header. */
 #define TPM_HEADER_SIZE (UINT32)(sizeof (TPM2_ST) + sizeof (UINT32) + sizeof (TPM2_CC))

--- a/src/tpm2-response.c
+++ b/src/tpm2-response.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,8 +26,9 @@
  */
 #include <errno.h>
 #include <inttypes.h>
+#include <stdlib.h>
 #include <string.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 #include "tpm2-header.h"
 #include "tpm2-response.h"

--- a/src/tpm2-response.h
+++ b/src/tpm2-response.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 #define TPM2_RESPONSE_H
 
 #include <glib-object.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 #include "connection.h"
 

--- a/src/tss2-tcti-echo.h
+++ b/src/tss2-tcti-echo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,7 @@
 #ifndef TSS2_TCTI_ECHO_H
 #define TSS2_TCTI_ECHO_H
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tcti.h>
 
 #define TCTI_ECHO_MAGIC 0xd511f126d4656f6d
 #define TSS2_TCTI_ECHO_MIN_BUF ( 1024 )

--- a/src/util.h
+++ b/src/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@
 
 #include <glib.h>
 #include <gio/gio.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 #include "control-message.h"
 

--- a/test/handle-map_unit.c
+++ b/test/handle-map_unit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,7 +25,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include <stdio.h>
-
+#include <stdlib.h>
 #include <setjmp.h>
 #include <cmocka.h>
 

--- a/test/integration/auth-session-max.int.c
+++ b/test/integration/auth-session-max.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 #include <glib.h>
 #include <stdio.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 #include "common.h"
 #include "test.h"

--- a/test/integration/auth-session-start-flush.int.c
+++ b/test/integration/auth-session-start-flush.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 #include <glib.h>
 #include <stdio.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 #include "common.h"
 #include "test.h"

--- a/test/integration/auth-session-start-save-load.int.c
+++ b/test/integration/auth-session-start-save-load.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 #include <glib.h>
 #include <stdio.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "common.h"
 #include "test.h"

--- a/test/integration/auth-session-start-save.int.c
+++ b/test/integration/auth-session-start-save.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 #include <glib.h>
 #include <stdio.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "common.h"
 #include "test.h"

--- a/test/integration/common.c
+++ b/test/integration/common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
  * These are common functions used by the integration tests.
  */
 #include <glib.h>
+#include <stdlib.h>
 
 #include "common.h"
 #include "tss2-tcti-tabrmd.h"

--- a/test/integration/common.h
+++ b/test/integration/common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,8 @@
  * These are common functions used by the integration tests.
  */
 #include <inttypes.h>
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
+#include <tss2/tss2_tcti.h>
 
 /*
  * This macro is useful as a wrapper around SAPI functions to automatically

--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "context-util.h"

--- a/test/integration/context-util.h
+++ b/test/integration/context-util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,9 @@
 #ifndef CONTEXT_UTIL_H
 #define CONTEXT_UTIL_H
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tcti.h>
+#include <tss2/tss2_sys.h>
+
 #include "test-options.h"
 
 /**

--- a/test/integration/create-keys.int.c
+++ b/test/integration/create-keys.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,7 @@
  */
 #include <glib.h>
 #include <inttypes.h>
+#include <stdlib.h>
 
 #include "tss2-tcti-tabrmd.h"
 #include "tpm2-struct-init.h"

--- a/test/integration/get-capability-handles-transient.int.c
+++ b/test/integration/get-capability-handles-transient.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,7 @@
  */
 #include <glib.h>
 #include <inttypes.h>
+#include <stdlib.h>
 
 #include "tss2-tcti-tabrmd.h"
 #include "tpm2-struct-init.h"

--- a/test/integration/hash-sequence.int.c
+++ b/test/integration/hash-sequence.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,8 +31,10 @@
 
 #include <glib.h>
 #include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "tabrmd.h"
 #include "tss2-tcti-tabrmd.h"

--- a/test/integration/main.c
+++ b/test/integration/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,7 @@
  */
 #include <glib.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
 #include "common.h"
 #include "tss2-tcti-tabrmd.h"

--- a/test/integration/not-enough-handles-for-command.int.c
+++ b/test/integration/not-enough-handles-for-command.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 #include <glib.h>
 #include <stdio.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "common.h"
 #include "test.h"

--- a/test/integration/password-authorization.int.c
+++ b/test/integration/password-authorization.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,7 @@
 
 #include <glib.h>
 #include <inttypes.h>
+#include <string.h>
 
 #include "tabrmd.h"
 #include "tss2-tcti-tabrmd.h"

--- a/test/integration/session-load-from-closed-connection.int.c
+++ b/test/integration/session-load-from-closed-connection.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,8 +27,9 @@
 #include <inttypes.h>
 #include <glib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 #include "common.h"
 #include "test-options.h"

--- a/test/integration/session-load-from-closed-connections-lru.int.c
+++ b/test/integration/session-load-from-closed-connections-lru.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,8 +28,9 @@
 #include <glib.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "common.h"
 #include "tabrmd.h"

--- a/test/integration/session-load-from-open-connection.int.c
+++ b/test/integration/session-load-from-open-connection.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,8 +27,9 @@
 #include <inttypes.h>
 #include <glib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "common.h"
 #include "test-options.h"

--- a/test/integration/start-auth-session.int.c
+++ b/test/integration/start-auth-session.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 #include <glib.h>
 #include <stdio.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "common.h"
 #include "test.h"

--- a/test/integration/tcti-connect-multiple.int.c
+++ b/test/integration/tcti-connect-multiple.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,6 +42,8 @@
 #include <glib.h>
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "tss2-tcti-tabrmd.h"
 #include "test-options.h"

--- a/test/integration/tcti-double-finalize.int.c
+++ b/test/integration/tcti-double-finalize.int.c
@@ -26,6 +26,7 @@
  */
 #include <glib.h>
 #include <inttypes.h>
+#include <tss2/tss2_sys.h>
 
 #include "tss2-tcti-tabrmd.h"
 

--- a/test/integration/tcti-sessions-max.int.c
+++ b/test/integration/tcti-sessions-max.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,7 @@
  */
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #include "tss2-tcti-tabrmd.h"

--- a/test/integration/test-options.c
+++ b/test/integration/test-options.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,7 +26,9 @@
  */
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <inttypes.h>
+#include <string.h>
 
 #include "test-options.h"
 #include "tss2-tcti-tabrmd.h"

--- a/test/integration/test-options.h
+++ b/test/integration/test-options.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,6 @@
 #define TEST_OPTIONS_H
 
 #include <gio/gio.h>
-#include <tss2/tpm20.h>
 #include "tss2-tcti-tabrmd.h"
 
 /* Default number of attempts to init selected TCTI */

--- a/test/integration/test.h
+++ b/test/integration/test.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,7 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 /*
  * This is the prototype for all integration tests in the TPM2.0-TSS

--- a/test/integration/tpm2-command-flush-no-handle.int.c
+++ b/test/integration/tpm2-command-flush-no-handle.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 #include <glib.h>
 #include <stdio.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "common.h"
 #include "test.h"

--- a/test/integration/util-buf-max-upper-bound.int.c
+++ b/test/integration/util-buf-max-upper-bound.int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 #include <glib.h>
 #include <stdio.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_sys.h>
 
 #include "common.h"
 #include "test.h"

--- a/test/tcti-dynamic_unit.c
+++ b/test/tcti-dynamic_unit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,6 +30,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "tcti-dynamic.h"
 #include "tabrmd.h"

--- a/test/tcti-util_unit.c
+++ b/test/tcti-util_unit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "tcti-util.h"
 #include "tabrmd.h"

--- a/test/tpm2-command_unit.c
+++ b/test/tpm2-command_unit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,6 +27,7 @@
 #include <glib.h>
 #include <inttypes.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <setjmp.h>
 #include <cmocka.h>

--- a/test/tss2-tcti-tabrmd_unit.c
+++ b/test/tss2-tcti-tabrmd_unit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,12 +29,14 @@
 #include <glib.h>
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/socket.h>
 
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include <tss2/tpm20.h>
+#include <tss2/tss2_tpm2_types.h>
 
 #include "tss2-tcti-tabrmd.h"
 #include "tcti-tabrmd-priv.h"

--- a/test/util_unit.c
+++ b/test/util_unit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,7 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 #include <setjmp.h>
 #include <cmocka.h>


### PR DESCRIPTION
The usptream tss2 libs and headers have seen some significant cleanup
and the removal of the tpm20.h header was one of them. This commit goes
through just about every source file in this repo and replaces the use
of tpm20.h with the appropriate header from upstream.

There were a lot of places where we were relying on tpm20.h to include
string.h, stdlib.h etc for us and so we've had to add these to the
offending source file here.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>