### PR TITLE
AccessBroker: define ABI version locally

### DIFF
--- a/src/access-broker.c
+++ b/src/access-broker.c
@@ -156,6 +156,15 @@ access_broker_class_init (AccessBrokerClass *klass)
                                        N_PROPERTIES,
                                        obj_properties);
 }
+
+#define SUPPORTED_ABI_VERSION \
+{ \
+    .tssCreator = 1, \
+    .tssFamily = 2, \
+    .tssLevel = 1, \
+    .tssVersion = 108, \
+}
+
 static TSS2_SYS_CONTEXT*
 sapi_context_init (Tcti *tcti)
 {
@@ -163,12 +172,7 @@ sapi_context_init (Tcti *tcti)
     TSS2_TCTI_CONTEXT *tcti_context;
     TSS2_RC rc;
     size_t size;
-    TSS2_ABI_VERSION abi_version = {
-        .tssCreator = TSSWG_INTEROP,
-        .tssFamily  = TSS_SAPI_FIRST_FAMILY,
-        .tssLevel   = TSS_SAPI_FIRST_LEVEL,
-        .tssVersion = TSS_SAPI_FIRST_VERSION,
-    };
+    TSS2_ABI_VERSION abi_version = SUPPORTED_ABI_VERSION;
 
     g_debug ("sapi_context_init w/ Tcti: 0x%" PRIxPTR, (uintptr_t)tcti);
     tcti_context = tcti_peek_context (tcti);

--- a/test/integration/common.c
+++ b/test/integration/common.c
@@ -73,12 +73,7 @@ sapi_context_init (TSS2_SYS_CONTEXT  **sapi_context,
     TSS2_SYS_CONTEXT *tmp_sapi_context;
     TSS2_RC rc;
     size_t size;
-    TSS2_ABI_VERSION abi_version = {
-        .tssCreator = TSSWG_INTEROP,
-        .tssFamily  = TSS_SAPI_FIRST_FAMILY,
-        .tssLevel   = TSS_SAPI_FIRST_LEVEL,
-        .tssVersion = TSS_SAPI_FIRST_VERSION,
-    };
+    TSS2_ABI_VERSION abi_version = SUPPORTED_ABI_VERSION;
 
     if (sapi_context == NULL || tcti_context == NULL)
         g_error ("sapi_context_init passed NULL reference");

--- a/test/integration/common.h
+++ b/test/integration/common.h
@@ -31,6 +31,15 @@
 #include <tss2/tss2_sys.h>
 #include <tss2/tss2_tcti.h>
 
+/* Current ABI version */
+#define SUPPORTED_ABI_VERSION \
+{ \
+    .tssCreator = 1, \
+    .tssFamily = 2, \
+    .tssLevel = 1, \
+    .tssVersion = 108, \
+}
+
 /*
  * This macro is useful as a wrapper around SAPI functions to automatically
  * retry function calls when the RC is TPM2_RC_RETRY.

--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -33,6 +33,7 @@
 
 #include "context-util.h"
 #include "tcti-util.h"
+#include "common.h"
 
 TSS2_TCTI_CONTEXT*
 tcti_dynamic_init (const char *filename,
@@ -96,12 +97,7 @@ sapi_init_from_tcti_ctx (TSS2_TCTI_CONTEXT *tcti_ctx)
     TSS2_SYS_CONTEXT *sapi_ctx;
     TSS2_RC rc;
     size_t size;
-    TSS2_ABI_VERSION abi_version = {
-        .tssCreator = TSSWG_INTEROP,
-        .tssFamily  = TSS_SAPI_FIRST_FAMILY,
-        .tssLevel   = TSS_SAPI_FIRST_LEVEL,
-        .tssVersion = TSS_SAPI_FIRST_VERSION,
-    };
+    TSS2_ABI_VERSION abi_version = SUPPORTED_ABI_VERSION;
 
     size = Tss2_Sys_GetContextSize (0);
     sapi_ctx = (TSS2_SYS_CONTEXT*)calloc (1, size);


### PR DESCRIPTION
TSS doesn't export the ABI defines in public heades anymore.
This is a follow up for https://github.com/tpm2-software/tpm2-tss/pull/864