### PR TITLE
INSTALL.md: Mention That Ldconfig Needs To Ran After Installing Libra…

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -272,6 +272,12 @@ you won't need to do much more than provide an alternative `--prefix` option
 at configure time, and maybe `DESTDIR` at install time if you're packaging
 for a distro.
 
+**NOTE**: It may be necessary to run ldconfig (as root) to update the run-time
+bindings before executing a program that links against the tabrmd library:
+```
+$ sudo ldconfig
+```
+
 # Post-install
 After installing the compiled software and configuration all components with
 new configuration (Systemd, D-Bus and udev) must be prompted to reload their


### PR DESCRIPTION
…ries

The INSTALL.md does not mention that ldconfig needs to ran after
"make install".  As a result, the tabrmd library cannot be found when running
executibles that use the library.

Fixes #396.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>