### PR TITLE
Tcti init cleanup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -105,20 +105,17 @@ noinst_LTLIBRARIES = \
     $(libtss2_tcti_echo) \
     $(libtest) \
     $(libutil)
-man3_MANS = man/man3/tss2_tcti_tabrmd_init.3
+man3_MANS = man/man3/Tss2_Tcti_Tabrmd_Init.3
 man7_MANS = man/man7/tss2-tcti-tabrmd.7
 man8_MANS = man/man8/tpm2-abrmd.8
 
-install-data-hook:
-	$(LN_S) -f tss2_tcti_tabrmd_init.3 \
-                $(DESTDIR)$(mandir)/man3/tss2_tcti_tabrmd_init_full.3
 if WITH_UDEVRULESPREFIX
+install-data-hook:
 	mv $(DESTDIR)$(udevrulesdir)/tpm-udev.rules $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
-endif
 
 uninstall-local:
-	-rm $(DESTDIR)$(mandir)/man3/tss2_tcti_tabrmd_init_full.3
 	-rm $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
+endif
 
 libtss2_tcti_tabrmddir      = $(includedir)/tcti
 libtss2_tcti_tabrmd_HEADERS = $(srcdir)/src/include/tss2-tcti-tabrmd.h
@@ -129,7 +126,7 @@ EXTRA_DIST = \
     test/integration/tpm2-struct-init.h \
     src/tcti-tabrmd.map \
     man/colophon.in \
-    man/tss2_tcti_tabrmd_init.3.in \
+    man/Tss2_Tcti_Tabrmd_Init.3.in \
     man/tss2-tcti-tabrmd.7.in \
     man/tpm2-abrmd.8.in \
     dist/tpm2-abrmd.conf \

--- a/man/Tss2_Tcti_Tabrmd_Init.3.in
+++ b/man/Tss2_Tcti_Tabrmd_Init.3.in
@@ -1,30 +1,28 @@
 .\" Process this file with
 .\" groff -man -Tascii foo.1
 .\"
-.TH TSS2_TCTI_TABRMD_INIT 3 "MAY 2017" Intel "TPM2 Software Stack"
+.TH TSS2_TCTI_TABRMD_INIT 3 "APRIL 2018" Intel "TPM2 Software Stack"
 .SH NAME
-tss2_tcti_tabrmd_init, tss2_tcti_tabrmd_init_full \- Initialization functions
-for the tpm2-abrmd TCTI library.
+Tss2_Tcti_Tabrmd_Init \- Initialization function for the tpm2-abrmd TCTI
+library.
 .SH SYNOPSIS
 The
-.BR tss2_tcti_tabrmd_init ()
-and
-.BR tss2_tcti_tabrmd_init_full ()
-functions are used to initialize a TCTI context for communication with the
+.BR Tss2_Tcti_Tabrmd_Init ()
+function is used to initialize a TCTI context for communication with the
 .BR tpm2-abrmd (8).
 .sp
 .B #include <tcti/tcti-tabrmd.h>
 .sp
-.BI "TSS2_RC tss2_tcti_tabrmd_init (TSS2_TCTI_CONTEXT " "*tcti_context" ", size_t " "*size" );
-.sp
-.BI "TSS2_RC tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT " "*tcti_context" ", size_t " "*size" ", GBusType" "bus_type" ", const char" "*bus_name" );
+.BI "TSS2_RC Tss2_Tcti_Tabrmd_Init (TSS2_TCTI_CONTEXT " "*tcti_context" ", size_t " "*size" ", const char " "*conf" );
 .sp
 .SH DESCRIPTION
-.BR tss2_tcti_tabrmd_init ()
+.BR Tss2_Tcti_Tabrmd_Init ()
 attempts to initialize a caller allocated
 .I tcti_context
 of size
 .I size
+with configuration specified in the configuration string
+.I conf.
 \&. Since the
 .I tcti_context
 must be a caller allocated buffer, the caller needs to know the size required
@@ -42,18 +40,38 @@ parameter with the minimum size of the
 .I tcti_context
 buffer. The caller my then allocate a buffer of this size (or larger) and
 call
-.B tss2_tcti_tabrmd_init ()
+.B tss2_Tcti_Tabrmd_Init ()
 again providing the newly allocated
 .I tcti_context
 and the size of this context in the
 .I size
-parameter.
-.sp
-This pattern is common to all TCTI initialization functions. We provide an
-example of this pattern using the
-.BR tss2_tcti_tabrmd_init ()
+parameter. This pattern is common to all TCTI initialization functions. We
+provide an example of this pattern using the
+.BR Tss2_Tcti_Tabrmd_Init ()
 function in the section titled
 .B EXAMPLE.
+.sp
+The
+.I conf
+parameter is a string of key / value pairs describing the desired connection
+properties for the TCTI. If the caller provides a NULL
+.I conf
+string then defaults that correspond to the defaults for the tpm2-abrmd (8)
+will be used. This is the same as providing the
+.I conf
+string: "bus_name=com.intel.tss2.Tabrmd,bus_type=system". Keys and values
+are separated by the '=' character while each key / value pair is separated by
+the ',' character. The supported keys and values are:
+.IP \[bu] 2
+.B bus_name
+- the dbus name owned by the daemon. See the tpm2-abrmd (8)
+.I --dbus-name
+option.
+.IP \[bu]
+.B bus_type
+- the bus type used for the connection with the daemon. The value associated
+with this key may be either "system" or "session".
+.RE
 .sp
 Once initialized, the TCTI context returned exposes the Trusted Computing
 Group (TCG) defined API for the lowest level communication with the TPM.
@@ -69,42 +87,25 @@ API and TPM Command Transmission Interface Specification\*(rq specification
 as published by the TCG:
 \%https://trustedcomputinggroup.org/tss-system-level-api-tpm-command-transmission-interface-specification/
 .sp
-.B tss2_tcti_tabrmd_init_full ()
-behaves in the same way as
-.B tss2_tcti_tabrmd_init ()
-but allows for greater flexibility through two additional parameters: The
-.I bus_type
-and
-.I bus_name
-parameters may be used to select which D-Bus bus type and name used to connect
-to an instance of the
-.B tpm2-abrmd (8)
-daemon.
 
 .SH RETURN VALUE
 A successful call to
-.BR tss2_tcti_tabrmd_init ()
-and
-.BR tss2_tcti_tabrmd_init_full ()
+.BR Tss2_Tcti_Tabrmd_Init ()
 will return
 .B TSS2_RC_SUCCESS.
 An unsuccessful call will produce a response code described in section
 .B ERRORS.
 .SH ERRORS
 .B TSS2_TCTI_RC_BAD_VALUE
-is returned if both the
-.I tcti_context
-and the
+is returned if the
 .I size
-parameters are NULL, or the
-.I bus_name
-is NULL, or the
-.I bus_type
-is not a supported type (G_BUS_TYPE_SYSTEM OR G_BUS_TYPE_SESSION).
+parameter is NULL.
 .sp
-All errors caused by communication failures with the
-.B tpm2-abrmd (8)
-are treated as fatal errors and will call the calling application to terminate.
+.B TSS2_TCTI_RC_NO_CONNECTION
+is returned when communication with the tpm2-abrmd (8) fails.
+.sp
+.B TSS2_TCTI_RC_GENERAL_FAILURE
+is returned for all other errors.
 
 .SH EXAMPLE
 .nf
@@ -117,7 +118,7 @@ TSS2_RC rc;
 TSS2_TCTI_CONTEXT *tcti_context;
 size_t size;
 
-rc = tss2_tcti_tabrmd_init (NULL, &size);
+rc = tss2_tcti_tabrmd_init (NULL, &size, NULL,
 if (rc != TSS2_RC_SUCCESS) {
     fprintf (stderr, "Failed to get allocation size for tabrmd TCTI "
              " context: 0x%" PRIx32 "\n", rc);
@@ -129,7 +130,7 @@ if (tcti_context == NULL) {
              strerror (errno));
     exit (EXIT_FAILURE);
 }
-rc = tss2_tcti_tabrmd_init (tcti_context, &size);
+rc = tss2_tcti_tabrmd_init (tcti_context, &size, NULL);
 if (rc != TSS2_RC_SUCCESS) {
     fprintf (stderr, "Failed to initialize tabrmd TCTI context: "
              "0x%" PRIx32 "\n", rc);

--- a/scripts/int-simulator-setup.sh
+++ b/scripts/int-simulator-setup.sh
@@ -135,7 +135,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # execute the test script and capture exit code
-env G_MESSAGES_DEBUG=all TABRMD_TEST_BUS_TYPE=session TABRMD_TEST_BUS_NAME="${TABRMD_NAME}" TABRMD_TEST_TCTI_RETRIES=10 $@
+env G_MESSAGES_DEBUG=all TABRMD_TEST_TCTI_CONF="bus_name=${TABRMD_NAME},bus_type=session" TABRMD_TEST_TCTI_RETRIES=10 $@
 ret_test=$?
 
 # This sleep is sadly necessary: If we kill the tabrmd w/o sleeping for a

--- a/src/include/tss2-tcti-tabrmd.h
+++ b/src/include/tss2-tcti-tabrmd.h
@@ -43,7 +43,9 @@ typedef enum {
     TCTI_TABRMD_DBUS_TYPE_SYSTEM,
 } TCTI_TABRMD_DBUS_TYPE;
 
-TSS2_RC tss2_tcti_tabrmd_init (TSS2_TCTI_CONTEXT *context, size_t *size);
+TSS2_RC Tss2_Tcti_Tabrmd_Init (TSS2_TCTI_CONTEXT *context,
+                               size_t *size,
+                               const char *conf);
 TSS2_RC tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT      *context,
                                     size_t                 *size,
                                     TCTI_TABRMD_DBUS_TYPE   bus,

--- a/src/include/tss2-tcti-tabrmd.h
+++ b/src/include/tss2-tcti-tabrmd.h
@@ -33,23 +33,9 @@ extern "C" {
 
 #include <tss2/tss2_tcti.h>
 
-#define TCTI_TABRMD_DBUS_INTERFACE_DEFAULT "com.intel.tss2.TctiTabrmd"
-#define TCTI_TABRMD_DBUS_NAME_DEFAULT      "com.intel.tss2.Tabrmd"
-#define TCTI_TABRMD_DBUS_TYPE_DEFAULT      TCTI_TABRMD_DBUS_TYPE_SYSTEM
-
-typedef enum {
-    TCTI_TABRMD_DBUS_TYPE_NONE,
-    TCTI_TABRMD_DBUS_TYPE_SESSION,
-    TCTI_TABRMD_DBUS_TYPE_SYSTEM,
-} TCTI_TABRMD_DBUS_TYPE;
-
 TSS2_RC Tss2_Tcti_Tabrmd_Init (TSS2_TCTI_CONTEXT *context,
                                size_t *size,
                                const char *conf);
-TSS2_RC tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT      *context,
-                                    size_t                 *size,
-                                    TCTI_TABRMD_DBUS_TYPE   bus,
-                                    const char             *name);
 
 #ifdef __cplusplus
 }

--- a/src/tabrmd.h
+++ b/src/tabrmd.h
@@ -30,14 +30,12 @@
 #include <gio/gio.h>
 
 #include <tss2/tss2_tpm2_types.h>
-
-#include "tss2-tcti-tabrmd.h"
+#include <tss2/tss2_tcti.h>
 
 #define TABRMD_CONNECTIONS_MAX_DEFAULT 27
 #define TABRMD_CONNECTION_MAX 100
-#define TABRMD_DBUS_INTERFACE_DEFAULT        TCTI_TABRMD_DBUS_INTERFACE_DEFAULT
-#define TABRMD_DBUS_NAME_DEFAULT             TCTI_TABRMD_DBUS_NAME_DEFAULT
-#define TABRMD_DBUS_TYPE_DEFAULT             TCTI_TABRMD_DBUS_TYPE_DEFAULT
+#define TABRMD_DBUS_NAME_DEFAULT "com.intel.tss2.Tabrmd"
+#define TABRMD_DBUS_TYPE_DEFAULT G_BUS_TYPE_SYSTEM
 #define TABRMD_DBUS_PATH                     "/com/intel/tss2/Tabrmd/Tcti"
 #define TABRMD_DBUS_METHOD_CREATE_CONNECTION "CreateConnection"
 #define TABRMD_DBUS_METHOD_CANCEL            "Cancel"

--- a/src/tcti-tabrmd-priv.h
+++ b/src/tcti-tabrmd-priv.h
@@ -111,9 +111,14 @@ typedef struct {
     uint8_t                        header_buf [TPM_HEADER_SIZE];
 } TSS2_TCTI_TABRMD_CONTEXT;
 
+#define TABRMD_CONF_INIT_DEFAULT { \
+    .bus_name = TABRMD_DBUS_NAME_DEFAULT, \
+    .bus_type = TABRMD_DBUS_TYPE_DEFAULT, \
+}
+
 typedef struct {
-    TCTI_TABRMD_DBUS_TYPE bus_type;
     const char *bus_name;
+    GBusType bus_type;
 } tabrmd_conf_t;
 
 /*
@@ -122,7 +127,7 @@ typedef struct {
  * private header so that we can invoke it in the test harness.
  */
 const TSS2_TCTI_INFO* Tss2_Tcti_Info (void);
-TCTI_TABRMD_DBUS_TYPE tabrmd_bus_type_from_str (const char* const bus_type);
+GBusType tabrmd_bus_type_from_str (const char* const bus_type);
 TSS2_RC tabrmd_conf_parse_kv (const char *key,
                               const char *value,
                               tabrmd_conf_t * const tabrmd_conf);

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -514,16 +514,6 @@ tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT      *context,
     return TSS2_RC_SUCCESS;
 }
 
-TSS2_RC
-tss2_tcti_tabrmd_init (TSS2_TCTI_CONTEXT *context,
-                       size_t            *size)
-{
-    return tss2_tcti_tabrmd_init_full (context,
-                                       size,
-                                       TCTI_TABRMD_DBUS_TYPE_DEFAULT,
-                                       TCTI_TABRMD_DBUS_NAME_DEFAULT);
-}
-
 typedef struct {
     TCTI_TABRMD_DBUS_TYPE type;
     char *name;
@@ -620,7 +610,7 @@ tabrmd_conf_parse (char *conf_str,
  * each another 9 characters for a total of 280.
  */
 #define CONF_STRING_MAX 280
-static TSS2_RC
+TSS2_RC
 Tss2_Tcti_Tabrmd_Init (TSS2_TCTI_CONTEXT *context,
                        size_t            *size,
                        const char        *conf)

--- a/src/tcti-tabrmd.map
+++ b/src/tcti-tabrmd.map
@@ -1,8 +1,8 @@
 {
     global:
-        tss2_tcti_tabrmd_init;
         tss2_tcti_tabrmd_init_full;
         tss2_tcti_tabrmd_dump_trans_state;
+        Tss2_Tcti_Tabrmd_Init;
         Tss2_Tcti_Info;
     local:
         *;

--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -58,14 +58,14 @@ tcti_dynamic_init (const char *filename,
  * Initialize a TCTI context for the tabrmd. Currently it requires no options.
  */
 TSS2_TCTI_CONTEXT*
-tcti_tabrmd_init (TCTI_TABRMD_DBUS_TYPE    bus_type,
-                  const char              *bus_name)
+tcti_tabrmd_init (const char *conf)
 {
     TSS2_RC rc;
     TSS2_TCTI_CONTEXT *tcti_ctx;
     size_t size;
 
-    rc = tss2_tcti_tabrmd_init_full (NULL, &size, bus_type, bus_name);
+    g_debug ("%s: with conf: \"%s\"", __func__, conf);
+    rc = Tss2_Tcti_Tabrmd_Init (NULL, &size, NULL);
     if (rc != TSS2_RC_SUCCESS) {
         fprintf (stderr, "Failed to get allocation size for tabrmd TCTI "
                  " context: 0x%" PRIx32 "\n", rc);
@@ -77,7 +77,7 @@ tcti_tabrmd_init (TCTI_TABRMD_DBUS_TYPE    bus_type,
                  strerror (errno));
         return NULL;
     }
-    rc = tss2_tcti_tabrmd_init_full (tcti_ctx, &size, bus_type, bus_name);
+    rc = Tss2_Tcti_Tabrmd_Init (tcti_ctx, &size, conf);
     if (rc != TSS2_RC_SUCCESS) {
         fprintf (stderr, "Failed to initialize tabrmd TCTI context: "
                  "0x%" PRIx32 "\n", rc);
@@ -151,8 +151,7 @@ tcti_init_from_opts (test_opts_t *options)
     if (options->tcti_filename != NULL) {
         return tcti_dynamic_init (options->tcti_filename, options->tcti_conf);
     } else {
-        return tcti_tabrmd_init (options->tabrmd_bus_type,
-                                 options->tabrmd_bus_name);
+        return tcti_tabrmd_init (options->tcti_conf);
     }
 }
 /*

--- a/test/integration/tcti-connect-multiple.int.c
+++ b/test/integration/tcti-connect-multiple.int.c
@@ -52,14 +52,13 @@
 
 TSS2_RC
 tcti_tabrmd_init (TSS2_TCTI_CONTEXT **tcti_context,
-                  TCTI_TABRMD_DBUS_TYPE bus_type,
-                  const char         *bus_name,
+                  const char         *conf,
                   int                 retries)
 {
     TSS2_RC rc;
     size_t size, i;
 
-    rc = tss2_tcti_tabrmd_init_full (NULL, &size, bus_type, bus_name);
+    rc = Tss2_Tcti_Tabrmd_Init (NULL, &size, NULL);
     if (rc != TSS2_RC_SUCCESS) {
         fprintf (stderr, "Failed to get allocation size for tabrmd TCTI "
                  " context: 0x%" PRIx32 "\n", rc);
@@ -72,10 +71,7 @@ tcti_tabrmd_init (TSS2_TCTI_CONTEXT **tcti_context,
         return rc;
     }
     for (i = 0; i < retries; ++i) {
-        rc = tss2_tcti_tabrmd_init_full (*tcti_context,
-                                         &size,
-                                         bus_type,
-                                         bus_name);
+        rc = Tss2_Tcti_Tabrmd_Init (*tcti_context, &size, conf);
         if (rc == TSS2_RC_SUCCESS) {
             break;
         } else {
@@ -114,8 +110,7 @@ main (int   argc,
     size_t i;
     for (i = 0; i < CONNECTION_COUNT; ++i) {
         rc = tcti_tabrmd_init (&tcti_context [i],
-                               opts.tabrmd_bus_type,
-                               opts.tabrmd_bus_name,
+                               opts.tcti_conf,
                                opts.tcti_retries);
         if (tcti_context [i] == NULL || rc != TSS2_RC_SUCCESS) {
             g_error ("failed to connect to TCTI: 0x%" PRIx32, rc);

--- a/test/integration/test-options.c
+++ b/test/integration/test-options.c
@@ -57,6 +57,7 @@ bus_str_from_type (TCTI_TABRMD_DBUS_TYPE bus_type)
         return NULL;
     }
 }
+
 /*
  * return 0 if sanity test passes
  * return 1 if sanity test fails
@@ -79,23 +80,21 @@ get_test_opts_from_env (test_opts_t          *test_opts)
     if (test_opts == NULL)
         return 1;
     env_str = getenv (ENV_TCTI);
-    if (env_str != NULL)
+    if (env_str != NULL) {
+        g_debug ("%s: %s is \"%s\"", __func__, ENV_TCTI, env_str);
         test_opts->tcti_filename = env_str;
-    env_str = getenv (ENV_TCTI_CONF);
-    if (env_str != NULL)
-        test_opts->tcti_conf = env_str;
-    env_str = getenv (ENV_TABRMD_BUS_TYPE);
-    if (env_str != NULL) {
-        test_opts->tabrmd_bus_type = bus_type_from_str (env_str);
     }
-    env_str = getenv (ENV_TABRMD_BUS_NAME);
+    env_str = getenv (ENV_TCTI_CONF);
     if (env_str != NULL) {
-        test_opts->tabrmd_bus_name = env_str;
+        g_debug ("%s: %s is \"%s\"", __func__, ENV_TCTI_CONF, env_str);
+        test_opts->tcti_conf = env_str;
     }
     env_str = getenv (ENV_TCTI_RETRIES);
     if (env_str != NULL) {
+        g_debug ("%s: %s is \"%s\"", __func__, ENV_TCTI_RETRIES, env_str);
         test_opts->tcti_retries = strtoumax (env_str, NULL, 10);
     }
+
     return 0;
 }
 /*
@@ -105,9 +104,7 @@ void
 dump_test_opts (test_opts_t *opts)
 {
     printf ("test_opts_t:\n");
-    printf ("  tcti_filename:   %s\n", opts->tcti_filename);
-    printf ("  tcti_conf:       %s\n", opts->tcti_conf);
-    printf ("  tabrmd_bus_type: %s\n", bus_str_from_type (opts->tabrmd_bus_type));
-    printf ("  tabrmd_bus_name: %s\n", opts->tabrmd_bus_name);
-    printf ("  retries:         %" PRIuMAX "\n", opts->tcti_retries);
+    printf ("  tcti_filename: %s\n", opts->tcti_filename);
+    printf ("  tcti_conf:     %s\n", opts->tcti_conf);
+    printf ("  retries:       %" PRIuMAX "\n", opts->tcti_retries);
 }

--- a/test/integration/test-options.c
+++ b/test/integration/test-options.c
@@ -30,28 +30,30 @@
 #include <inttypes.h>
 #include <string.h>
 
+#include <gio/gio.h>
+
 #include "test-options.h"
 #include "tss2-tcti-tabrmd.h"
 
-TCTI_TABRMD_DBUS_TYPE
+GBusType
 bus_type_from_str (const char *bus_type_str)
 {
     if (strcmp (bus_type_str, "system") == 0) {
-        return TCTI_TABRMD_DBUS_TYPE_SYSTEM;
+        return G_BUS_TYPE_SYSTEM;
     } else if (strcmp (bus_type_str, "session") == 0) {
-        return TCTI_TABRMD_DBUS_TYPE_SESSION;
+        return G_BUS_TYPE_SESSION;
     } else {
         g_error ("Invalid bus type for %s", bus_type_str);
-        return TCTI_TABRMD_DBUS_TYPE_DEFAULT;
+        return G_BUS_TYPE_NONE;
     }
 }
 const char*
-bus_str_from_type (TCTI_TABRMD_DBUS_TYPE bus_type)
+bus_str_from_type (GBusType bus_type)
 {
     switch (bus_type) {
-    case TCTI_TABRMD_DBUS_TYPE_SESSION:
+    case G_BUS_TYPE_SESSION:
         return "session";
-    case TCTI_TABRMD_DBUS_TYPE_SYSTEM:
+    case G_BUS_TYPE_SYSTEM:
         return "system";
     default:
         return NULL;

--- a/test/integration/test-options.h
+++ b/test/integration/test-options.h
@@ -52,8 +52,8 @@ typedef struct {
 
 /* functions to get test options from the user and to print helpful stuff */
 
-const char  *bus_name_from_type         (TCTI_TABRMD_DBUS_TYPE bus_type);
-TCTI_TABRMD_DBUS_TYPE bus_type_from_str (const char*           bus_type_str);
+const char  *bus_str_from_type          (GBusType              bus_type);
+GBusType     bus_type_from_str          (const char*           bus_type_str);
 int          get_test_opts_from_env     (test_opts_t          *opts);
 int          sanity_check_test_opts     (test_opts_t          *opts);
 void         dump_test_opts             (test_opts_t          *opts);

--- a/test/integration/test-options.h
+++ b/test/integration/test-options.h
@@ -36,23 +36,17 @@
 /* environment variables holding TCTI config */
 #define ENV_TCTI      "TABRMD_TEST_TCTI"
 #define ENV_TCTI_CONF "TABRMD_TEST_TCTI_CONF"
-#define ENV_TABRMD_BUS_TYPE "TABRMD_TEST_BUS_TYPE"
-#define ENV_TABRMD_BUS_NAME "TABRMD_TEST_BUS_NAME"
 #define ENV_TCTI_RETRIES    "TABRMD_TEST_TCTI_RETRIES"
 
 #define TEST_OPTS_DEFAULT_INIT { \
     .tcti_filename = NULL, \
     .tcti_conf = NULL, \
-    .tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT, \
-    .tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT, \
     .tcti_retries = TCTI_RETRIES_DEFAULT, \
 }
 
 typedef struct {
     const char *tcti_filename;
     const char *tcti_conf;
-    TCTI_TABRMD_DBUS_TYPE tabrmd_bus_type;
-    const char *tabrmd_bus_name;
     uintmax_t   tcti_retries;
 } test_opts_t;
 

--- a/test/tss2-tcti-tabrmd_unit.c
+++ b/test/tss2-tcti-tabrmd_unit.c
@@ -38,6 +38,7 @@
 
 #include <tss2/tss2_tpm2_types.h>
 
+#include "tabrmd.h"
 #include "tss2-tcti-tabrmd.h"
 #include "tcti-tabrmd-priv.h"
 #include "tpm2-header.h"
@@ -98,33 +99,33 @@ tcti_tabrmd_info_test (void **state)
 }
 /*
  * Ensure that when we pass the string "session" to the
- * tabrmd_bus_type_from_str returns TCTI_TABRMD_DBUS_TYPE_SESSION.
+ * tabrmd_bus_type_from_str returns G_BUS_TYPE_SESSION.
  */
 static void
 tcti_tabrmd_bus_type_from_str_session_test (void **state)
 {
     assert_int_equal (tabrmd_bus_type_from_str ("session"),
-                      TCTI_TABRMD_DBUS_TYPE_SESSION);
+                      G_BUS_TYPE_SESSION);
 }
 /*
  * Ensure that when we pass the string "system" to the
- * tabrmd_bus_type_from_str returns TCTI_TABRMD_DBUS_TYPE_SYSTEM.
+ * tabrmd_bus_type_from_str returns G_BUS_TYPE_SYSTEM.
  */
 static void
 tcti_tabrmd_bus_type_from_str_system_test (void **state)
 {
     assert_int_equal (tabrmd_bus_type_from_str ("system"),
-                      TCTI_TABRMD_DBUS_TYPE_SYSTEM);
+                      G_BUS_TYPE_SYSTEM);
 }
 /*
  * Ensure that when we pass an unexpected string to the
- * tabrmd_bus_type_from_str returns TCTI_TABRMD_DBUS_TYPE_NONE.
+ * tabrmd_bus_type_from_str returns G_BUS_TYPE_NONE.
  */
 static void
 tcti_tabrmd_bus_type_from_str_bad_test (void **state)
 {
     assert_int_equal (tabrmd_bus_type_from_str ("foobar"),
-                      TCTI_TABRMD_DBUS_TYPE_NONE);
+                      G_BUS_TYPE_NONE);
 }
 /*
  * Ensure that when we pass the key "bus_name" and value "any string"
@@ -144,7 +145,7 @@ tcti_tabrmd_conf_parse_kv_name_test (void **state)
 /*
  * Ensure that when we pass the key "bus_type" and the value "system"
  * to tabrmd_conf_parse_kv that it returns an RC indicating success while
- * the conf structure 'bus_type' field is set to TCTI_TABRMD_DBUS_TYPE_SYSTEM.
+ * the conf structure 'bus_type' field is set to G_BUS_TYPE_SYSTEM.
  */
 static void
 tcti_tabrmd_conf_parse_kv_type_good_test (void **state)
@@ -154,13 +155,13 @@ tcti_tabrmd_conf_parse_kv_type_good_test (void **state)
 
     rc = tabrmd_conf_parse_kv ("bus_type", "system", &conf);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (conf.bus_type, TCTI_TABRMD_DBUS_TYPE_SYSTEM);
+    assert_int_equal (conf.bus_type, G_BUS_TYPE_SYSTEM);
 }
 /*
  * Ensure that when we pass the key "bus_type" and with an invalid value
  * string (not "system" or "session") that it returns the BAD_VALUE RC and
  * sets the 'bus_type' field of the conf structure to
- * TCTI_TABRMD_DBUS_TYPE_NONE.
+ * G_BUS_TYPE_NONE.
  */
 static void
 tcti_tabrmd_conf_parse_kv_type_bad_test (void **state)
@@ -170,7 +171,7 @@ tcti_tabrmd_conf_parse_kv_type_bad_test (void **state)
 
     rc = tabrmd_conf_parse_kv ("bus_type", "foo", &conf);
     assert_int_equal (rc, TSS2_TCTI_RC_BAD_VALUE);
-    assert_int_equal (conf.bus_type, TCTI_TABRMD_DBUS_TYPE_NONE);
+    assert_int_equal (conf.bus_type, G_BUS_TYPE_NONE);
 }
 /*
  * Ensure that when we pass an invalid key (not 'bus_type' or 'bus_name')
@@ -199,7 +200,7 @@ tcti_tabrmd_conf_parse_named_session_test (void **state)
     rc = tabrmd_conf_parse (conf_str, &conf);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_string_equal (conf.bus_name, "com.example.Session");
-    assert_int_equal (conf.bus_type, TCTI_TABRMD_DBUS_TYPE_SESSION);
+    assert_int_equal (conf.bus_type, G_BUS_TYPE_SESSION);
 }
 /*
  * Ensure that a common config string selecting the system bus with
@@ -215,7 +216,7 @@ tcti_tabrmd_conf_parse_named_system_test (void **state)
     rc = tabrmd_conf_parse (conf_str, &conf);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_string_equal (conf.bus_name, "com.example.System");
-    assert_int_equal (conf.bus_type, TCTI_TABRMD_DBUS_TYPE_SYSTEM);
+    assert_int_equal (conf.bus_type, G_BUS_TYPE_SYSTEM);
 }
 /*
  * Ensure that an unknown bus_type string results in the appropriate RC.
@@ -238,13 +239,13 @@ static void
 tcti_tabrmd_conf_parse_no_name_test (void **state)
 {
     TSS2_RC rc;
-    tabrmd_conf_t conf = { 0 };
+    tabrmd_conf_t conf = TABRMD_CONF_INIT_DEFAULT;
     char conf_str[] = "bus_type=session";
 
     rc = tabrmd_conf_parse (conf_str, &conf);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_string_equal (conf.bus_name, TCTI_TABRMD_DBUS_NAME_DEFAULT);
-    assert_int_equal (conf.bus_type, TCTI_TABRMD_DBUS_TYPE_SESSION);
+    assert_string_equal (conf.bus_name, TABRMD_DBUS_NAME_DEFAULT);
+    assert_int_equal (conf.bus_type, G_BUS_TYPE_SESSION);
 }
 /*
  * Ensure that a config string that omits the bus_type results in a conf
@@ -254,13 +255,13 @@ static void
 tcti_tabrmd_conf_parse_no_type_test (void **state)
 {
     TSS2_RC rc;
-    tabrmd_conf_t conf = { 0 };
+    tabrmd_conf_t conf = TABRMD_CONF_INIT_DEFAULT;
     char conf_str[] = "bus_name=com.example.FooBar";
 
     rc = tabrmd_conf_parse (conf_str, &conf);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_string_equal (conf.bus_name, "com.example.FooBar");
-    assert_int_equal (conf.bus_type, TCTI_TABRMD_DBUS_TYPE_DEFAULT);
+    assert_int_equal (conf.bus_type, TABRMD_DBUS_TYPE_DEFAULT);
 }
 /*
  * Ensure that a missing value results in the appropriate RC.
@@ -269,7 +270,7 @@ static void
 tcti_tabrmd_conf_parse_no_value_test (void **state)
 {
     TSS2_RC rc;
-    tabrmd_conf_t conf = { 0 };
+    tabrmd_conf_t conf = TABRMD_CONF_INIT_DEFAULT;
     char conf_str[] = "bus_name=";
 
     rc = tabrmd_conf_parse (conf_str, &conf);
@@ -282,7 +283,7 @@ static void
 tcti_tabrmd_conf_parse_no_key_test (void **state)
 {
     TSS2_RC rc;
-    tabrmd_conf_t conf = { 0 };
+    tabrmd_conf_t conf = TABRMD_CONF_INIT_DEFAULT;
     char conf_str[] = "=some-string";
 
     rc = tabrmd_conf_parse (conf_str, &conf);

--- a/test/tss2-tcti-tabrmd_unit.c
+++ b/test/tss2-tcti-tabrmd_unit.c
@@ -51,7 +51,7 @@ tcti_tabrmd_init_size_test (void **state)
 {
     size_t tcti_size;
 
-    tss2_tcti_tabrmd_init (NULL, &tcti_size);
+    Tss2_Tcti_Tabrmd_Init (NULL, &tcti_size, NULL);
     assert_int_equal (tcti_size, sizeof (TSS2_TCTI_TABRMD_CONTEXT));
 }
 /*
@@ -64,7 +64,7 @@ tcti_tabrmd_init_success_return_value_test (void **state)
     size_t tcti_size;
     TSS2_RC ret;
 
-    ret = tss2_tcti_tabrmd_init (NULL, &tcti_size);
+    ret = Tss2_Tcti_Tabrmd_Init (NULL, &tcti_size, NULL);
     assert_int_equal (ret, TSS2_RC_SUCCESS);
 }
 /*
@@ -76,7 +76,7 @@ tcti_tabrmd_init_allnull_is_bad_value_test (void **state)
 {
     TSS2_RC ret;
 
-    ret = tss2_tcti_tabrmd_init (NULL, NULL);
+    ret = Tss2_Tcti_Tabrmd_Init (NULL, NULL, NULL);
     assert_int_equal (ret, TSS2_TCTI_RC_BAD_VALUE);
 }
 /*
@@ -382,7 +382,7 @@ tcti_tabrmd_setup (void **state)
     guint64 id = 666;
 
     data = calloc (1, sizeof (data_t));
-    ret = tss2_tcti_tabrmd_init (NULL, &tcti_size);
+    ret = Tss2_Tcti_Tabrmd_Init (NULL, &tcti_size, NULL);
     if (ret != TSS2_RC_SUCCESS) {
         printf ("tss2_tcti_tabrmd_init failed: %d\n", ret);
         return 1;
@@ -400,11 +400,7 @@ tcti_tabrmd_setup (void **state)
                  data->client_fd);
     data->id = id;
     will_return (__wrap_g_dbus_proxy_call_with_unix_fd_list_sync, id);
-    g_debug ("about to call real tss2_tcti_tabrmd_init function");
-    ret = tss2_tcti_tabrmd_init_full (data->context,
-                                      0,
-                                      TCTI_TABRMD_DBUS_TYPE_SESSION,
-                                      TCTI_TABRMD_DBUS_NAME_DEFAULT);
+    ret = Tss2_Tcti_Tabrmd_Init (data->context, &tcti_size, "bus_type=session");
     assert_int_equal (ret, TSS2_RC_SUCCESS);
 
     *state = data;


### PR DESCRIPTION
The two patches in this PR remove the two legacy init functions: `tss2_tcti_tabrmd_init` and `tss2_tcti_tabrmd_init_full`. Once these are removed then the only supported initialization mechanism is the "standard" one: `Tss2_Tcti_Tabrmd_Init`.