### PR TITLE
tcti: Generalize the key / value parsing from the conf string.

### DIFF
--- a/src/tcti-tabrmd-priv.h
+++ b/src/tcti-tabrmd-priv.h
@@ -33,6 +33,7 @@
 
 #include "tabrmd-generated.h"
 #include "tpm2-header.h"
+#include "util.h"
 
 #define TSS2_TCTI_TABRMD_MAGIC 0x1c8e03ff00db0f92
 #define TSS2_TCTI_TABRMD_VERSION 1
@@ -128,10 +129,7 @@ typedef struct {
  */
 const TSS2_TCTI_INFO* Tss2_Tcti_Info (void);
 GBusType tabrmd_bus_type_from_str (const char* const bus_type);
-TSS2_RC tabrmd_conf_parse_kv (const char *key,
-                              const char *value,
-                              tabrmd_conf_t * const tabrmd_conf);
-TSS2_RC tabrmd_conf_parse (char *conf_str,
-                           tabrmd_conf_t * const tabrmd_conf);
+TSS2_RC tabrmd_kv_callback (const key_value_t *key_value,
+                            gpointer user_data);
 
 #endif /* TSS2TCTI_TABRMD_PRIV_H */

--- a/src/util.h
+++ b/src/util.h
@@ -42,6 +42,14 @@
 #define UTIL_BUF_MAX  8*UTIL_BUF_SIZE
 
 #define prop_str(val) val ? "set" : "clear"
+
+typedef struct {
+    char *key;
+    char *value;
+} key_value_t;
+
+typedef TSS2_RC (*KeyValueFunc) (const key_value_t* key_value,
+                                 gpointer user_data);
 /*
 #define TPM2_CC_FROM_TPMA_CC(attrs) (attrs.val & 0x0000ffff)
 #define TPMA_CC_RESERVED(attrs)    (attrs.val & 0x003f0000)
@@ -76,4 +84,8 @@ int         create_socket_pair              (int              *fd_a,
                                              int              *fd_b,
                                              int               flags);
 void        g_debug_tpma_cc                 (TPMA_CC           tpma_cc);
+TSS2_RC     parse_key_value_string (char *kv_str,
+                                    KeyValueFunc callback,
+                                    gpointer user_data);
+
 #endif /* UTIL_H */


### PR DESCRIPTION
This commit moves the basics of parsing a string of key / value pairs of
the form "key0=value0,key1=value1,..." from the TCTI module to the util
module. This is the part that parses on "=" and ",". To make this
generic we now provide a callback function that the parsing function
will call passing each parsed key / value pair and a reference to some
caller-provided data.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>