### PR TITLE
tcti: Fix bad return value from init function.

### DIFF
--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -641,7 +641,7 @@ out:
     g_clear_pointer (&conf_copy, g_free);
     g_clear_error (&error);
 
-    return TSS2_RC_SUCCESS;
+    return rc;
 }
 
 /* public info structure */


### PR DESCRIPTION
This now returns the persisted reponse code from previous calls instead
of just blindly returning SUCCESS.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>