### PR TITLE
docs: Clarify requirement that commits *not* contain unrelated changes.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,10 @@ consider this the window for comments.
 
 ## Patch requirements
 * All tests must pass on Travis CI for the merge to occur.
-* All changes must not introduce superfluous changes or whitespace errors.
 * All changes should adhere to the coding standard.
+* All commits must be accurately described by the associated commit message
+and be limited to a single "unit" of change as described in:
+http://www.ericbmerritt.com/2011/09/21/commit-hygiene-and-git.html
 * All commits should adhere to the git commit message guidlines described
 here: https://chris.beams.io/posts/git-commit/ with the following exceptions.
  * We allow commit subject lines up to 80 characters.


### PR DESCRIPTION
Getting this requirement clearly stated in a single list entry isn't
easy. Thankfully there are some good resources describing the philosophy
behind this requirement as well as the mechanics of the `git` tool that
make it possible.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>