### PR TITLE
Fix Spelling Errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ consider this the window for comments.
 * All tests must pass on Travis CI for the merge to occur.
 * All changes must not introduce superfluous changes or whitespace errors.
 * All changes should adhere to the coding standard.
-* All commits should adhere to the git commit message guidlines described
+* All commits should adhere to the git commit message guidelines described
 here: https://chris.beams.io/posts/git-commit/ with the following exceptions.
  * We allow commit subject lines up to 80 characters.
  * Commit subject lines should be prefixed with a string identifying the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,7 +44,7 @@ We do not however encourage users to build from git unless they intend to modify
 For the end user we provide release "tarballs" following the GNU conventions as closely as possible.
 
 To make a release tarball use the `distcheck` make target.
-This target incldues a number of sanity checks that are extremely helpful.
+This target includes a number of sanity checks that are extremely helpful.
 For more information on `automake` and release tarballs see: https://www.gnu.org/software/automake/manual/html_node/Dist.html#Dist
 
 ## Hosting Releases on Github

--- a/doc/coding_standard_c.md
+++ b/doc/coding_standard_c.md
@@ -179,7 +179,8 @@ of the associated control flow statement on a line by itself.
 Function definitions specify the return type on a line, followed by the
 function name followed by the first parameter. Each additional parameter is
 listed on a separate line aligned with the line above. The opening brace
-defning the functions scope must be on the following line at column position 0.
+defining the function's scope must be on the following line at column
+position 0.
 
 A space must separate a control flow statement or function and the opening
 parenthesis.

--- a/m4/flags.m4
+++ b/m4/flags.m4
@@ -1,6 +1,6 @@
 dnl AX_ADD_COMPILER_FLAG:
 dnl   A macro to add a CFLAG to the EXTRA_CFLAGS variable. This macro will
-dnl   check to be sure the compiler supprts the flag. Flags can be made
+dnl   check to be sure the compiler supports the flag. Flags can be made
 dnl   mandatory (configure will fail).
 dnl $1: C compiler flag to add to EXTRA_CFLAGS.
 dnl $2: Set to "required" to cause configure failure if flag not supported..
@@ -17,10 +17,10 @@ AC_DEFUN([AX_ADD_COMPILER_FLAG],[
 dnl AX_ADD_PREPROC_FLAG:
 dnl   Add the provided preprocessor flag to the EXTRA_CFLAGS variable. This
 dnl   macro will check to be sure the preprocessor supports the flag.
-dnl   The flag can be made mandatory by provideing the string 'required' as
+dnl   The flag can be made mandatory by providing the string 'required' as
 dnl   the second parameter.
 dnl $1: Preprocessor flag to add to EXTRA_CFLAGS.
-dnl $2: Set to "required" t ocause configure failure if preprocesor flag
+dnl $2: Set to "required" t ocause configure failure if preprocessor flag
 dnl     is not supported.
 AC_DEFUN([AX_ADD_PREPROC_FLAG],[
     AX_CHECK_PREPROC_FLAG([$1],[
@@ -34,7 +34,7 @@ AC_DEFUN([AX_ADD_PREPROC_FLAG],[
 )
 dnl AX_ADD_LINK_FLAG:
 dnl   A macro to add a LDLAG to the EXTRA_LDFLAGS variable. This macro will
-dnl   check to be sure the linker supprts the flag. Flags can be made
+dnl   check to be sure the linker supports the flag. Flags can be made
 dnl   mandatory (configure will fail).
 dnl $1: linker flag to add to EXTRA_LDFLAGS.
 dnl $2: Set to "required" to cause configure failure if flag not supported.

--- a/man/Tss2_Tcti_Tabrmd_Init.3.in
+++ b/man/Tss2_Tcti_Tabrmd_Init.3.in
@@ -79,7 +79,7 @@ Using this API the caller can exchange (send / receive) TPM2 command and
 response buffers with the
 .B tpm2-abrmd (8).
 In nearly all cases however, the caller
-will initialize a context using this funnction before passing the context to
+will initialize a context using this function before passing the context to
 a higher level API like the System API (SAPI), and then never touch it again.
 .sp
 For a more thorough discussion of the TCTI API see the \*(lqTSS System Level

--- a/scripts/int-hardware-setup.sh
+++ b/scripts/int-hardware-setup.sh
@@ -28,7 +28,7 @@
 set -u
 set +o nounset
 
-# default int-test-funcs script, overriden in TEST_FUNCTIONS env variable
+# default int-test-funcs script, overridden in TEST_FUNCTIONS env variable
 TEST_FUNC_LIB=${TEST_FUNC_LIB:-scripts/int-test-funcs.sh}
 if [ -e ${TEST_FUNC_LIB} ]; then
     . ${TEST_FUNC_LIB}

--- a/scripts/int-simulator-setup.sh
+++ b/scripts/int-simulator-setup.sh
@@ -28,7 +28,7 @@
 set -u
 set +o nounset
 
-# default int-test-funcs script, overriden in TEST_FUNCTIONS env variable
+# default int-test-funcs script, overridden in TEST_FUNCTIONS env variable
 TEST_FUNC_LIB=${TEST_FUNC_LIB:-scripts/int-test-funcs.sh}
 if [ -e ${TEST_FUNC_LIB} ]; then
     . ${TEST_FUNC_LIB}


### PR DESCRIPTION
Fix spelling errors in directories doc, m4, man, and scripts,
and files CONTRIBUTING.md and RELEASE.md.

Fixes #416.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>