### PR TITLE
build: don't install a TPM udev rule

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -145,30 +145,6 @@ started by systemd on boot. If you wish for the daemon to be disabled by
 default some reason you may use this option to the `configure` script to do
 so.
 
-### udev Rules
-The typical operation for the `tpm2-abrmd` is for it to communicate directly
-with the Linux TPM driver using `libtcti-device` from the TPM2.0-TSS project.
-This requires that the user account that's running the `tpm2-abrmd` have both
-read and write access to the TPM device node `/dev/tpm[0-9]`.
-
-#### `--with-udevrulesdir`
-This requires that `udev` be instructed to set the owner and group for this
-device node when its created. We provide such a udev rule that is installed to
-`${libdir}/udev/rules.d`. If your distro stores these rules elsewhere you will
-need to tell the build about this location.
-
-Using Debian as an example we can instruct the build to install the udev
-rules in the right location with the following configure option:
-```
---with-udevrulesdir=/etc/udev/rules.d
-```
-
-#### `--with-udevrulesprefix`
-It is common for Linux distros to prefix udev rules files with a numeric
-string (e.g. "70-"). This allows for the rules to be applied in a predictable
-order. This option allows for the name of the installed udev rules file to
-have a string prepended to the file name when it is installed.
-
 
 #### `--datarootdir`
 To override the system data directory, used for
@@ -280,23 +256,12 @@ $ sudo ldconfig
 
 # Post-install
 After installing the compiled software and configuration all components with
-new configuration (Systemd, D-Bus and udev) must be prompted to reload their
-configs. This can be accomplished by restarting your system but this isn't
-strictly necessary and is generally considered bad form.
+new configuration (Systemd and D-Bus) must be prompted to reload their configs.
+This can be accomplished by restarting your system but this isn't strictly
+necessary and is generally considered bad form.
 
 Instead each component can be instructed to reload its config manually. The
 following sections describe this process for each.
-
-## udev
-Once you have this udev rule installed in the right place for your distro
-you'll need to instruct udev to reload its rules and apply the new rule.
-Typically this can be accomplished with the following command:
-```
-$ sudo udevadm control --reload-rules && sudo udevadm trigger
-```
-
-If this doesn't work on your distro please consult your distro's
-documentation for UDEVADM(8).
 
 ## D-Bus
 The dbus-daemon will also need to be instructed to read this configuration

--- a/Makefile.am
+++ b/Makefile.am
@@ -109,14 +109,6 @@ man3_MANS = man/man3/Tss2_Tcti_Tabrmd_Init.3
 man7_MANS = man/man7/tss2-tcti-tabrmd.7
 man8_MANS = man/man8/tpm2-abrmd.8
 
-if WITH_UDEVRULESPREFIX
-install-data-hook:
-	mv $(DESTDIR)$(udevrulesdir)/tpm-udev.rules $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
-
-uninstall-local:
-	-rm $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
-endif
-
 libtss2_tcti_tabrmddir      = $(includedir)/tcti
 libtss2_tcti_tabrmd_HEADERS = $(srcdir)/src/include/tss2-tcti-tabrmd.h
 
@@ -133,7 +125,6 @@ EXTRA_DIST = \
     dist/tpm2-abrmd.preset.in \
     dist/tss2-tcti-tabrmd.pc.in \
     dist/tpm2-abrmd.service.in \
-    dist/tpm-udev.rules \
     dist/com.intel.tss2.Tabrmd.service \
     scripts/int-simulator-setup.sh \
     scripts/int-hardware-setup.sh \
@@ -167,7 +158,6 @@ BUILT_SOURCES = src/tabrmd-generated.h src/tabrmd-generated.c
 pkgconfigdir     = $(libdir)/pkgconfig
 pkgconfig_DATA   = dist/tss2-tcti-tabrmd.pc
 dbuspolicy_DATA  = dist/tpm2-abrmd.conf
-udevrules_DATA   = dist/tpm-udev.rules
 if HAVE_SYSTEMD
 systemdpreset_DATA = dist/tpm2-abrmd.preset
 systemdsystemunit_DATA = dist/tpm2-abrmd.service

--- a/configure.ac
+++ b/configure.ac
@@ -106,19 +106,6 @@ AC_ARG_WITH([dbuspolicydir],
 AX_NORMALIZE_PATH([with_dbuspolicydir])
 AC_SUBST([dbuspolicydir], [$with_dbuspolicydir])
 #
-# udev
-#
-AC_ARG_WITH([udevrulesdir],
-            [AS_HELP_STRING([--with-udevrulesdir=DIR],[udev rules directory])],
-            [],
-            [with_udevrulesdir=${libdir}/udev/rules.d])
-AX_NORMALIZE_PATH([with_udevrulesdir])
-AC_SUBST([udevrulesdir], [$with_udevrulesdir])
-AC_ARG_WITH([udevrulesprefix],
-            [AS_HELP_STRING([--with-udevrulesprefix=XY],[prefix for udev rules file])],
-            [AC_SUBST([udevrulesprefix],[$with_udevrulesprefix])])
-AM_CONDITIONAL(WITH_UDEVRULESPREFIX, [test -n "$with_udevrulesprefix"])
-#
 # simulator binary
 #
 AC_MSG_CHECKING([for simulator binary: $with_simulatorbin])

--- a/dist/tpm-udev.rules
+++ b/dist/tpm-udev.rules
@@ -1,2 +1,0 @@
-# tpm2-abrmd should be run as unprivileged tss user
-KERNEL=="tpmrm[0-9]*|tpm[0-9]*", MODE="0660", OWNER="tss", GROUP="tss"


### PR DESCRIPTION
This should be done in the tpm2-tss instead, since conceptually the lower
layers of the stack are the ones that access the TPM character devices.

Also, users may want to access the TPM directly without using a resource
manager in user-space.

Fixes: #412

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>