### PR TITLE
Fix Bugs Found by Clang Scan-build Static Code Analyzer

### DIFF
--- a/src/access-broker.c
+++ b/src/access-broker.c
@@ -219,6 +219,11 @@ access_broker_lock (AccessBroker *broker)
 {
     gint error;
 
+    if (broker == NULL) {
+        g_error ("AccessBroker: NULL pointer passed to access_broker_lock");
+        return;
+    }
+
     error = pthread_mutex_lock (&broker->sapi_mutex);
     if (error != 0) {
         switch (error) {
@@ -243,6 +248,11 @@ void
 access_broker_unlock (AccessBroker *broker)
 {
     gint error;
+
+    if (broker == NULL) {
+        g_error ("AccessBroker: NULL pointer passed to access_broker_unlock");
+        return;
+    }
 
     error= pthread_mutex_unlock (&broker->sapi_mutex);
     if (error != 0) {
@@ -329,6 +339,12 @@ access_broker_get_fixed_property (AccessBroker           *broker,
 TSS2_SYS_CONTEXT*
 access_broker_lock_sapi (AccessBroker *broker)
 {
+    if (broker == NULL) {
+        g_error (
+            "AccessBroker: NULL pointer passed to access_broker_lock_sapi");
+        return NULL;
+    }
+
     access_broker_lock (broker);
     g_assert_nonnull (broker->sapi_context);
     return broker->sapi_context;

--- a/src/random.c
+++ b/src/random.c
@@ -86,6 +86,11 @@ random_seed_from_file (Random *random,
     long int rand_seed = 0;
     ssize_t read_ret;
 
+    if (random == NULL) {
+        g_error ("NULL random pointer passed to random_seed_from_file");
+        return -1;
+    }
+
     g_debug ("opening entropy source: %s", fname);
     g_assert_nonnull (random);
     rand_fd = open (fname, O_RDONLY);
@@ -155,6 +160,12 @@ random_get_uint64 (Random      *random)
     size_t ret;
     uint64_t dest;
 
+    if (random == NULL) {
+        g_error ("NULL random pointer passed to random_get_uint64");
+        return -1;
+    }
+
+
     ret = random_get_bytes (random, (uint8_t*)&dest, sizeof (uint64_t));
     g_assert_true (ret == sizeof (uint64_t));
 
@@ -170,6 +181,12 @@ random_get_uint32 (Random       *random)
 {
     size_t ret;
     uint32_t dest;
+
+    if (random == NULL) {
+        g_error ("NULL random pointer passed to random_get_uint32");
+        return -1;
+    }
+
 
     ret = random_get_bytes (random, (uint8_t*)&dest, sizeof (uint32_t));
     g_assert_true (ret == sizeof (uint32_t));


### PR DESCRIPTION
Fixes unchecked NULL parameters.
Fixes #425.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>