### PR TITLE
test: Remove bad NULL struct from CMUnitTest array.

### DIFF
--- a/test/command-attrs_unit.c
+++ b/test/command-attrs_unit.c
@@ -310,8 +310,6 @@ main (void)
         cmocka_unit_test_setup_teardown (command_attrs_from_cc_fail_test,
                                          command_attrs_init_tpm_setup,
                                          command_attrs_teardown),
-        { NULL, NULL, NULL, NULL, NULL }
-
     };
     return cmocka_run_group_tests (tests, NULL, NULL);
 }


### PR DESCRIPTION
The CMUnitTest type only has 4 membbers and the NULL struct here has 5
members. This isn't required anyways so the cleanest thing to do is to
just remove it.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>