### PR TITLE
tcti: Set version field to 2 to correspond with public review TCTI spec.

### DIFF
--- a/src/tcti-tabrmd-priv.h
+++ b/src/tcti-tabrmd-priv.h
@@ -36,7 +36,7 @@
 #include "util.h"
 
 #define TSS2_TCTI_TABRMD_MAGIC 0x1c8e03ff00db0f92
-#define TSS2_TCTI_TABRMD_VERSION 1
+#define TSS2_TCTI_TABRMD_VERSION 2
 
 #define TSS2_TCTI_TABRMD_ID(context) \
     ((TSS2_TCTI_TABRMD_CONTEXT*)context)->id

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -624,9 +624,13 @@ out:
 
 /* public info structure */
 static const TSS2_TCTI_INFO tss2_tcti_info = {
+    .version = TSS2_TCTI_TABRMD_VERSION,
     .name = "tcti-abrmd",
     .description = "TCTI module for communication with tabrmd.",
-    .config_help = "This module takes NO arguments.",
+    .config_help = "This conf string is a series of key / value pairs " \
+        "where keys and values are separated by the '=' character and " \
+        "each pair is separated by the ',' character. Valid keys are " \
+        "\"bus_name\" and \"bus_type\".",
     .init = Tss2_Tcti_Tabrmd_Init,
 };
 

--- a/test/tss2-tcti-tabrmd_unit.c
+++ b/test/tss2-tcti-tabrmd_unit.c
@@ -505,7 +505,7 @@ tcti_tabrmd_version_test (void **state)
 {
     data_t *data = *state;
 
-    assert_int_equal (TSS2_TCTI_VERSION (data->context), 1);
+    assert_int_equal (TSS2_TCTI_VERSION (data->context), TSS2_TCTI_TABRMD_VERSION);
 }
 /*
  * Ensure that after initialization the 'id' value set for the connection is


### PR DESCRIPTION
The conf_help string is also updated in the INFO structure to describe
the format of the 'conf' parameter.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>