### PR TITLE
test: Update int-test-setup.sh to use the new mssim TCTI conf string.

### DIFF
--- a/scripts/int-test-setup.sh
+++ b/scripts/int-test-setup.sh
@@ -162,7 +162,7 @@ in
         done
         TABRMD_NAME="com.intel.tss2.Tabrmd${SIM_PORT_DATA}"
         TABRMD_OPTS="${TABRMD_OPTS} --dbus-name=${TABRMD_NAME}"
-        TABRMD_OPTS="${TABRMD_OPTS} --tcti=${TABRMD_TCTI}:tcp://127.0.0.1:${SIM_PORT_DATA}"
+        TABRMD_OPTS="${TABRMD_OPTS} --tcti=${TABRMD_TCTI}:port=${SIM_PORT_DATA}"
         TABRMD_TEST_TCTI_CONF="${TABRMD_TEST_TCTI_CONF},bus_name=${TABRMD_NAME}"
         ;;
     "device")


### PR DESCRIPTION
This commit replaces use of the old tcp:// URI in the tcti conf string
with the new string of key / value pairs. Additionally we now omit the
`host` component since the default is `localhost`.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>