### PR TITLE
Get capability handles transient fix off by one

### DIFF
--- a/test/integration/get-capability-handles-transient.int.c
+++ b/test/integration/get-capability-handles-transient.int.c
@@ -128,7 +128,7 @@ get_transient_handles (TSS2_SYS_CONTEXT *sapi_context,
         more_data == 1 ? g_print ("more data\n") : g_print ("no more data\n");
     } while (more_data == 1);
 
-    *handle_count = handles_got + 1;
+    *handle_count = handles_got;
 
     return TSS2_RC_SUCCESS;
 }

--- a/test/integration/get-capability-handles-transient.int.c
+++ b/test/integration/get-capability-handles-transient.int.c
@@ -225,6 +225,11 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         g_warning ("get_transient_handles returned 0x%" PRIx32, rc);
         return rc;
     }
+    if (handles_count != loops) {
+        g_warning ("GetCapabilities returned %zu handles, expecting %" PRIu16,
+                   handles_count, loops);
+        return -1;
+    }
 
     g_debug ("loaded handle count: %zu", handles_count);
     for (i = 0; i < handles_count; ++i) {


### PR DESCRIPTION
This is two commits fixing up a bug, and adding an additional sanity check to the `get-capability-handles-transient.int.c` test case.