### PR TITLE
build: Replace --with-simulatorbin option with --enable-integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ env:
     - LD_LIBRARY_PATH="${DESTDIR}${PREFIX}/lib:${LD_LIBRARY_PATH}"
     - CFLAGS="-I${DESTDIR}${PREFIX}/include"
     - CMOCKA_LIBS="-L${DESTDIR}${PREFIX}/lib -lcmocka"
+    - PATH="${DEPS}/ibmtpm/src:${PATH}"
 
 install:
   - pip install --user cpp-coveralls
@@ -85,7 +86,7 @@ script :
     fi
   - echo 'Configuring source code...' && echo -en 'travis_fold:start:tabrmd-configure\\r'
   - |
-    CONFIGURE_OPTIONS="--disable-dlclose --enable-unit --with-simulatorbin=${DEPS}/ibmtpm/src/tpm_server"
+    CONFIGURE_OPTIONS="--disable-dlclose --enable-unit --enable-integration"
     if [ "$CC" = "gcc" ]; then
         CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --enable-code-coverage"
     fi

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -188,23 +188,19 @@ warned.
 
 The next two subsections describe these two configurations:
 
-### Run Integration Tests with TPM2 simulator: `--with-simulatorbin`
+### Run Integration Tests: `--enable-integration`
+If the configure script is passed the `--enable-integration` option then the
+test harness will execute the integration tests against the software TPM2
+simulator. The configure script will check for the existance of the software
+TPM2 simulator executable `tpm_server` on the PATH. An instance of the
+simulator will be created for each test executable to allow the parallel
+execution of test cases.
+
 This is the recommended integration test configuration. It requires that you
 first download and compile the TPM2 software simulator as documented by the
-simulators maintainers.
-
-Once you have the `tpm_server` built you can inform the tpm2-abrmd build of
-its location by passing an absolute path to the `./configure` script through
-the `--with-simulatorbin` option:
-```
-$ ./configure --with-simulatorbin=/path/to/tpm_server
-```
-
-If the configure script is able to find the executable you provide through this
-option then executing `make check` will cause the integration tests to be built
-and executed. The test harness in the build system will run a `tpm_server` and
-`tpm2-abrmd` for each test executable. This allows the test harness to execute
-integration tests in parallel.
+simulators maintainers. Once you have the `tpm_server` built, you must ensure
+that it is discoverable via the PATH environment variable when the
+`./configure` script is run.
 
 **NOTE**: The `--with-simulatorbin` option does not change the default for
 tpm2-abrmd, which is to use TPM hardware.
@@ -227,6 +223,9 @@ run the integration tests against the TPM2 device by passing the
 ```
 $ ./configure --enable-test-hwtpm
 ```
+Providing this option will enable the integration tests much like the
+`--enable-integration` but the configure script will not check for the
+simulator executable.
 
 The test harness can then be run with the typical `make check` though there
 are some limitations due to the use of the hardware TPM:

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,16 +69,17 @@ TESTS_INTEGRATION_NOHW = test/integration/tcti-connect-multiple.int
 TESTS = $(TESTS_INTEGRATION)
 XFAIL_TESTS = test/integration/start-auth-session.int
 TEST_EXTENSIONS = .int
-AM_TESTS_ENVIRONMENT = TEST_FUNC_LIB=$(srcdir)/scripts/int-test-funcs.sh
+AM_TESTS_ENVIRONMENT = \
+    TEST_FUNC_LIB=$(srcdir)/scripts/int-test-funcs.sh \
+    PATH=./src:$(PATH)
 INT_LOG_COMPILER = $(srcdir)/scripts/int-test-setup.sh
-INT_LOG_FLAGS = --tabrmd-bin=$(sbin_PROGRAMS) --tabrmd-tcti=$(TABRMD_TCTI)
+INT_LOG_FLAGS = --tabrmd-tcti=$(TABRMD_TCTI)
 
 if HWTPM
 TABRMD_TCTI = device
 endif
 
-if SIMULATOR_BIN
-INT_LOG_FLAGS += --simulator-bin=$(SIMULATOR_BIN)
+if ENABLE_INTEGRATION
 TABRMD_TCTI = mssim
 TESTS += $(TESTS_INTEGRATION_NOHW)
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -106,35 +106,31 @@ AC_ARG_WITH([dbuspolicydir],
 AX_NORMALIZE_PATH([with_dbuspolicydir])
 AC_SUBST([dbuspolicydir], [$with_dbuspolicydir])
 #
-# simulator binary
-#
-AC_MSG_CHECKING([for simulator binary: $with_simulatorbin])
-AC_ARG_WITH([simulatorbin],
-            [AS_HELP_STRING([--with-simulatorbin=tpm_server],[simulator executable])],
-            [AS_IF([test \( -f "$with_simulatorbin" \) -a \( -x "$with_simulatorbin" \)],
-                   [AC_MSG_RESULT([yes])
-                    AC_SUBST([SIMULATOR_BIN],[$with_simulatorbin])
-                    AX_NORMALIZE_PATH([with_simulatorbin])
-                    with_simulatorbin_set=yes],
-                   [AC_MSG_RESULT([no])
-                    AC_MSG_ERROR([Simulator binary provided does not exist or not executable. Check path: $with_simulatorbin])])],
-            [AC_MSG_RESULT([no])
-             with_simulatorbin_set=no])
-AM_CONDITIONAL([SIMULATOR_BIN],[test "x$with_simulatorbin_set" = "xyes"])
-#
 # Real TPM hardware
 #
 AC_ARG_ENABLE([test-hwtpm],
               [AS_HELP_STRING([--enable-test-hwtpm],
                   [enable the integration test on a real tpm hardware (default is no)])],
-              [enable_hwtpm=$enableval],
+              [enable_hwtpm=$enableval
+               enable_integration=$enableval],
               [enable_hwtpm=no])
-AS_IF([test \( "x$with_simulatorbin_set" = "xyes" \) -a \( "x$enable_hwtpm" = "xyes" \) ],
-      AC_MSG_ERROR([--with-simulatorbin cannot be provided with --enable-test-hwtpm.]))
 AM_CONDITIONAL([HWTPM], [test "x$enable_hwtpm" != xno])
-
-AS_IF([test \( "x$with_simulatorbin_set" = "xno" \) -a \( "x$enable_hwtpm" = "xno" \) ],
-      AC_MSG_WARN([No simulator binary or tpm hardware provided. Integration tests disabled.]))
+#
+# enable integration tests and check for simulator binary
+#
+AC_ARG_ENABLE([integration],
+    [AS_HELP_STRING([--enable-integration],
+        [build and execute integration tests (default is no)])],
+    [enable_integration=$enableval],
+    [enable_integration=no])
+AS_IF([test \( "x$enable_integration" = "xyes" \) -a \( "x$enable_hwtpm" = "xno" \)],
+    [AC_CHECK_PROG([tpm_server], [tpm_server], [yes], [no])
+     AS_IF([test "x$tpm_server" != "xyes"],
+         [AC_MSG_ERROR([Integration tests enabled but tpm_server not found, try setting PATH])])
+     AC_SUBST([ENABLE_INTEGRATION],[$enable_integration])
+     AC_MSG_NOTICE([Integration tests will be executed against the TPM2 simulator.])],
+    [AC_MSG_NOTICE([Integration tests will be executed against the TPM device.])])
+AM_CONDITIONAL([ENABLE_INTEGRATION],[test "x$enable_integration" = "xyes"])
 
 # preprocessor / compiler / linker flags
 #   these macros are defined in m4/flags.m4
@@ -158,5 +154,7 @@ AX_ADD_LINK_FLAG([-Wl,--no-undefined])
 AX_ADD_LINK_FLAG([-Wl,-z,noexecstack])
 AX_ADD_LINK_FLAG([-Wl,-z,now])
 AX_ADD_LINK_FLAG([-Wl,-z,relro])
+
+AC_SUBST([PATH])
 
 AC_OUTPUT


### PR DESCRIPTION
The --with-simulatorbin option was a bit awkward as it required passing
the absolute path to the simulator executable. Just having the configure
script check the callers PATH to make sure it's there is a lot cleaner.
This implies that if `--enable-integration` is passed to configure the
caller must have the `tpm_server` executable on their PATH.

Additionally the configure script must export the PATH as it was when the
configure script was executed. The Makefile must then propagate the PATH
to the test script as its executed.

The INSTALL.md file is updated to describe all of this as well as to
document the interaction between this new option with the
`--enable-test-hwtpm` option.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>