### PR TITLE
build: Disable GCC 8 -Wcast-function-type warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -141,6 +141,9 @@ AX_ADD_COMPILER_FLAG([-std=gnu99])
 AX_ADD_COMPILER_FLAG([-Wformat])
 AX_ADD_COMPILER_FLAG([-Wformat-security])
 AX_ADD_COMPILER_FLAG([-Wno-missing-braces])
+# work around for Glib usage of function pointers type casting
+#   https://bugzilla.gnome.org/show_bug.cgi?id=793272
+AX_ADD_COMPILER_FLAG([-Wno-cast-function-type])
 AX_ADD_COMPILER_FLAG([-fdata-sections])
 AX_ADD_COMPILER_FLAG([-ffunction-sections])
 AX_ADD_COMPILER_FLAG([-fstack-protector-all])


### PR DESCRIPTION
GCC 8 introduces a -Wcast-function-type warning, that warns about type casts
that changes functions signatures. The C standard says that function pointer
of any type may be converted to a pointer to a function of another type and
back again, but calling the converted pointer is an undefined behaviour.

The problem is that GLib relies on this undefined behaviour and type casting
between different functions signatures is quite common. For example, this is
a compile error that happens because the command_source_on_input_ready which
is a function of type GPollableSourceFunc, is casted to GSourceFunc:

  CC       src/src_libutil_la-util.lo
src/command-source.c: In function ‘command_source_on_new_connection’:
src/command-source.c:287:28: error: cast between incompatible function types from ‘gboolean (*)(GInputStream *, void *)’ {aka ‘int (*)(struct _GInputStream *, void *)’} to ‘gboolean (*)(void *)’ {aka ‘int (*)(void *)’} [-Werror=cast-function-type]
                            (GSourceFunc)command_source_on_input_ready,
                            ^
cc1: all warnings being treated as errors
make[1]: *** [Makefile:2328: src/src_libutil_la-command-source.lo] Error 1
make[1]: *** Waiting for unfinished jobs....
In file included from /usr/include/glib-2.0/glib/glist.h:32,
                 from /usr/include/glib-2.0/glib/ghash.h:33,
                 from /usr/include/glib-2.0/glib.h:50,
                 from src/util.h:30,
                 from src/tcti-dynamic.c:31:
src/tcti-dynamic.c: In function ‘tcti_dynamic_finalize’:
/usr/include/glib-2.0/glib/gmem.h:120:31: error: cast between incompatible function types from ‘int (*)(void *)’ to ‘void (*)(void *)’ [-Werror=cast-function-type]
     GDestroyNotify _destroy = (GDestroyNotify) (destroy);                      \
                               ^
src/tcti-dynamic.c:108:5: note: in expansion of macro ‘g_clear_pointer’
     g_clear_pointer (&tcti_dynamic->tcti_dl_handle, dlclose);
     ^~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:2475: src/src_libutil_la-tcti-dynamic.lo] Error 1
make[1]: Leaving directory '/home/javier/devel/tpm2-abrmd'
make: *** [Makefile:1616: all] Error 2

Since tpm2-abrmd uses Glib extensively, let's disable -Wcast-function-type.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>