### PR TITLE
build: Treat warnings as errors when checking compiler for flag support.

### DIFF
--- a/m4/flags.m4
+++ b/m4/flags.m4
@@ -11,7 +11,8 @@ AC_DEFUN([AX_ADD_COMPILER_FLAG],[
         AS_IF([test x$2 != xrequired],[
             AC_MSG_WARN([Optional CFLAG "$1" not supported by your compiler, continuing.])],[
             AC_MSG_ERROR([Required CFLAG "$1" not supported by your compiler, aborting.])]
-        )]
+        )],[
+        -Werror]
     )]
 )
 dnl AX_ADD_PREPROC_FLAG:
@@ -29,7 +30,8 @@ AC_DEFUN([AX_ADD_PREPROC_FLAG],[
         AS_IF([test x$2 != xrequired],[
             AC_MSG_WARN([Optional preprocessor flag "$1" not supported by your compiler, continuing.])],[
             AC_MSG_ERROR([Required preprocessor flag "$1" not supported by your compiler, aborting.])]
-        )]
+        )],[
+        -Werror]
     )]
 )
 dnl AX_ADD_LINK_FLAG:
@@ -45,6 +47,7 @@ AC_DEFUN([AX_ADD_LINK_FLAG],[
         AS_IF([test x$2 != xrequired],[
             AC_MSG_WARN([Optional LDFLAG "$1" not supported by your linker, continuing.])],[
             AC_MSG_ERROR([Required LDFLAG "$1" not supported by your linker, aborting.])]
-        )]
+        )],[
+        -Werror]
     )]
 )


### PR DESCRIPTION
The command executed by the AX_CHECK_*_FLAG macro will cause clang to
report a warning when a flag isn't supported. But if we pass this flag
to the build the compilation will fail. So we have to force the warning
to be treated as an error when AX_CHECK_*_FLAG is executed by adding
-Werror to CFLAGS for the check.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>