### PR TITLE
Fix Compiler Warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,12 @@ script :
   - echo 'Configuring source code...' && echo -en 'travis_fold:start:tabrmd-configure\\r'
   - |
     CONFIGURE_OPTIONS="--disable-dlclose --enable-unit --enable-integration"
+    if [[ "$CC" == clang* ]]; then
+        # Use -D_REENTRANT kludge so -pthread test works with scan-build:
+        scan-build ./configure CFLAGS="$CFLAGS -D_REENTRANT" $CONFIGURE_OPTIONS
+        dbus-launch scan-build --status-bugs make -j$(nproc) distcheck
+        make clean
+    fi
     if [ "$CC" = "gcc" ]; then
         CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --enable-code-coverage"
     fi

--- a/src/access-broker.c
+++ b/src/access-broker.c
@@ -589,7 +589,8 @@ access_broker_get_trans_object_count (AccessBroker *broker,
                                  NULL);
     if (rc != TSS2_RC_SUCCESS)
         goto out;
-    *count = capability_data.data.handles.count;
+    if (count != NULL)
+        *count = capability_data.data.handles.count;
 out:
     access_broker_unlock (broker);
     return rc;

--- a/src/util.h
+++ b/src/util.h
@@ -35,6 +35,16 @@
 
 /* Use to suppress "unused parameter" warnings: */
 #define UNUSED_PARAM(p) ((void)(p))
+/* Use to suppress "unused variable" warnings: */
+#define UNUSED_VAR(p) ((void)(p))
+
+/* Used to suppress scan-build NULL dereference warnings: */
+#ifdef SCANBUILD
+#define ASSERT_NON_NULL(x) assert_non_null(x); \
+            if ((x) == NULL) return
+#else
+#define ASSERT_NON_NULL(x) assert_non_null(x)
+#endif
 
 /* set the layer / component to indicate the RC comes from the RM */
 #define RM_RC(rc) TSS2_RESMGR_RC_LAYER + rc

--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -362,11 +362,12 @@ resource_manager_load_contexts_test (void **state)
     GSList         *entry_slist;
     HandleMap      *map;
     SessionList    *loaded_sessions;
-    TPM2_HANDLE      phandles [2] = {
+    TPM2_HANDLE      phandles [3] = {
         TPM2_HR_TRANSIENT + 0xeb,
         TPM2_HR_TRANSIENT + 0xbe,
+        0
     };
-    TPM2_HANDLE      vhandles [3] = { 0 };
+    TPM2_HANDLE      vhandles [3] = { 0, 0, 0 };
     TPM2_HANDLE      handle_ret;
     TSS2_RC         rc = TSS2_RC_SUCCESS;
     size_t          handle_count = 2, i;
@@ -378,6 +379,7 @@ resource_manager_load_contexts_test (void **state)
 
     tpm2_command_get_handles (data->command, vhandles, &handle_count);
     map = connection_get_trans_map (data->connection);
+    assert_true (handle_count <= 2);
     for (i = 0; i < handle_count; ++i) {
         entry = handle_map_entry_new (phandles [i], vhandles [i]);
         handle_map_insert (map, vhandles [i], entry);
@@ -391,6 +393,7 @@ resource_manager_load_contexts_test (void **state)
                                          loaded_sessions);
     g_debug ("after resource_manager_load_contexts");
     assert_int_equal (rc, TSS2_RC_SUCCESS);
+    assert_true (handle_count <= 2);
     for (i = 0; i < handle_count; ++i) {
         handle_ret = tpm2_command_get_handle (data->command, i);
         assert_int_equal (phandles [i], handle_ret);

--- a/test/tss2-tcti-echo_unit.c
+++ b/test/tss2-tcti-echo_unit.c
@@ -335,12 +335,16 @@ tss2_tcti_echo_transmit_success_unit (void **state)
     TCTI_ECHO_CONTEXT *echo_context = (TCTI_ECHO_CONTEXT*)data->tcti_context;
     uint8_t buffer [TSS2_TCTI_ECHO_MAX_BUF] = { 0xde, 0xad, 0xbe, 0xef, 0x0 };
     TSS2_RC rc;
+    size_t  buf_size;
+
+    ASSERT_NON_NULL(echo_context);
+    buf_size = echo_context->buf_size;
 
     rc = Tss2_Tcti_Transmit (data->tcti_context,
                              TSS2_TCTI_ECHO_MAX_BUF,
                              buffer);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_memory_equal (buffer, echo_context->buf, echo_context->buf_size);
+    assert_memory_equal (buffer, echo_context->buf, buf_size);
     assert_int_equal (echo_context->data_size, TSS2_TCTI_ECHO_MAX_BUF);
     assert_int_equal (echo_context->state, CAN_RECEIVE);
 }

--- a/test/tss2-tcti-tabrmd_unit.c
+++ b/test/tss2-tcti-tabrmd_unit.c
@@ -603,6 +603,8 @@ tcti_tabrmd_transmit_success_test (void **state)
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     ret = read (data->server_fd, command_out, size);
     assert_int_equal (ret, size);
+    ASSERT_NON_NULL(data);
+    ASSERT_NON_NULL(data->context);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_RECEIVE);
     assert_memory_equal (command_in, command_out, size);
@@ -782,6 +784,8 @@ tcti_tabrmd_receive_success_test (void **state)
                             command_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
+    ASSERT_NON_NULL(data);
+    ASSERT_NON_NULL(data->context);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_TRANSMIT);
     assert_int_equal (size, sizeof (command_in));
@@ -823,6 +827,8 @@ tcti_tabrmd_receive_poll_eintr_test (void **state)
                             command_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
+    ASSERT_NON_NULL(data);
+    ASSERT_NON_NULL(data->context);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_TRANSMIT);
     assert_int_equal (size, sizeof (command_in));
@@ -840,6 +846,8 @@ tcti_tabrmd_receive_poll_fail_test (void **state)
     size_t size = sizeof (command_in);
     uint8_t command_out [sizeof (command_in)] = { 0 };
     TSS2_RC rc;
+
+    UNUSED_VAR(command_in);
 
     will_return (__wrap_poll, 0);
     will_return (__wrap_poll, ENOMEM);
@@ -861,6 +869,8 @@ tcti_tabrmd_receive_poll_timeout_test (void **state)
     uint8_t command_in [] = { 0x80, 0x02,
                               0x00, 0x00, 0x00, 0x0a,
                               0x00, 0x00, 0x00, 0x00 };
+    UNUSED_VAR(command_in);
+
     size_t size = sizeof (command_in);
     uint8_t command_out [sizeof (command_in)] = { 0 };
     TSS2_RC rc;
@@ -967,6 +977,8 @@ tcti_tabrmd_receive_bad_timeout_test (void **state)
     uint8_t command_out [sizeof (command_in)] = { 0 };
     TSS2_RC rc;
 
+    UNUSED_VAR(command_in);
+
     rc = Tss2_Tcti_Receive (data->context,
                             &size,
                             command_out,
@@ -1022,6 +1034,8 @@ tcti_tabrmd_receive_size_lt_header_test (void **state)
                             response,
                             TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_TCTI_RC_INSUFFICIENT_BUFFER);
+    ASSERT_NON_NULL(data);
+    ASSERT_NON_NULL(data->context);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_RECEIVE);
 }
@@ -1054,6 +1068,8 @@ tcti_tabrmd_receive_size_lt_body_test (void **state)
                             buffer_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_TCTI_RC_INSUFFICIENT_BUFFER);
+    ASSERT_NON_NULL(data);
+    ASSERT_NON_NULL(data->context);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_RECEIVE);
 }
@@ -1087,6 +1103,8 @@ tcti_tabrmd_receive_error_first_read_test (void **state)
                             buffer_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_TCTI_RC_TRY_AGAIN);
+    ASSERT_NON_NULL(data);
+    ASSERT_NON_NULL(data->context);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_RECEIVE);
 }
@@ -1119,6 +1137,8 @@ tcti_tabrmd_receive_malformed_header_test (void **state)
                             buffer_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_TCTI_RC_MALFORMED_RESPONSE);
+    ASSERT_NON_NULL(data);
+    ASSERT_NON_NULL(data->context);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_TRANSMIT);
 }
@@ -1206,6 +1226,8 @@ tcti_tabrmd_receive_get_size_test (void **state)
                             NULL,
                             TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
+    ASSERT_NON_NULL(data);
+    ASSERT_NON_NULL(data->context);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_RECEIVE);
     assert_int_equal (size, 0x0e);
@@ -1240,7 +1262,9 @@ tcti_tabrmd_receive_get_size_and_body_test (void **state)
                             NULL,
                             TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
+    assert_non_null(data->context);
+    if ((data != NULL  && data->context != NULL))
+        assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_RECEIVE);
     assert_int_equal (size, 0x0e);
 
@@ -1257,6 +1281,8 @@ tcti_tabrmd_receive_get_size_and_body_test (void **state)
                             buffer_out,
                             TSS2_TCTI_TIMEOUT_BLOCK);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
+    ASSERT_NON_NULL(data);
+    ASSERT_NON_NULL(data->context);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_TRANSMIT);
     assert_memory_equal (buffer_in, buffer_out, sizeof (buffer_in));
@@ -1277,6 +1303,8 @@ tcti_tabrmd_cancel_test (void **state)
     will_return (__wrap_tcti_tabrmd_call_cancel_sync, TRUE);
     rc = Tss2_Tcti_Cancel (data->context);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
+    ASSERT_NON_NULL(data);
+    ASSERT_NON_NULL(data->context);
     assert_int_equal (TSS2_TCTI_TABRMD_STATE (data->context),
                       TABRMD_STATE_RECEIVE);
 }
@@ -1367,6 +1395,8 @@ tcti_tabrmd_get_poll_handles_handles_test (void **state)
     rc = Tss2_Tcti_GetPollHandles (data->context, handles, &num_handles);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (1, num_handles);
+    ASSERT_NON_NULL(data);
+    ASSERT_NON_NULL(data->context);
     fd = TSS2_TCTI_TABRMD_FD (data->context);
     assert_int_equal (handles [0].fd, fd);
 }


### PR DESCRIPTION
Fix compiler warnings about possible NULL pointer dereferences,
memory leaks, and unused variables.

Fixes #448.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>