### PR TITLE
Revert "Add scan-build Static Code Analysis to Travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,18 +89,11 @@ script :
     CONFIGURE_OPTIONS="--disable-dlclose --enable-unit --enable-integration"
     if [ "$CC" = "gcc" ]; then
         CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --enable-code-coverage"
-        ./configure ${CONFIGURE_OPTIONS}
-    elif [ "$CC" == "clang" ]; then
-        export CFLAGS="-D_REENTRANT" # scan-build kludge so -pthread test works
-        scan-build ./configure ${CONFIGURE_OPTIONS}
-        SCANBUILD="scan-build --status-bugs"
-    else
-        echo "Unsupported CC=$CC"
-        exit 1
     fi
+    ./configure ${CONFIGURE_OPTIONS}
   - echo -en 'travis_fold:end:tabrmd-configure\\r'
   - echo "Running make 'distcheck' target..." && echo -en 'travis_fold:start:tabrmd-distcheck\\r'
-  - dbus-launch $SCANBUILD make -j$(nproc) distcheck
+  - dbus-launch make -j$(nproc) distcheck
   - echo -en 'travis_fold:end:tabrmd-distcheck\\r'
   - echo "Running make 'check-code-coverage' target..." && echo -en 'travis_fold:start:tabrmd-check-code-coverage\\r'
   - dbus-launch make -j$(nproc) check-code-coverage


### PR DESCRIPTION
This reverts commit f05f2a850efc88b99e87da31a2316053fe0fe45f. The issue
with this commit is that, while it enables scan-build, it overwrites the
contents of CFLAGS and causes the build to fail (all -I directives to
the compiler have been lost and so it can't find the TSS@ headers). Odly
enough, because scan-build didn't find any errors (the build failed so
no errors to find) it still reports success. This isn't what we want.

The right solution here will preserve CFLAGS. A simple change like this
however causes the build to pass complete, scan-build to run, but it
then finds a pile of issues and so the build fails. For the short-term
we're reverting this commit and will resubmit it once the issues
identified by scan-build are resolved.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>