### PR TITLE
tpm2-abrmd: Rename 'max-transient-objects' option to 'max-transients'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a CHANGELOG](http://keepachangelog.com/)
 ### Added
 - Integration test script and build support to execute integration tests
 against a physical TPM2 device on the build platform.
+### Changed
+- 'max-transient-objects' command line option renamted to 'max-transients'.
 ### Removed
 - Command line option --fail-on-loaded-trans.
 

--- a/man/tpm2-abrmd.8.in
+++ b/man/tpm2-abrmd.8.in
@@ -60,7 +60,7 @@ default is \fBstdout\fR.
 Set and upper bound on the number of sessions that each client connection
 is allowed to create (loaded or active) at any one time.
 .TP
-\fB\-r,\ \-\-max-transient-objects\fR
+\fB\-r,\ \-\-max-transients\fR
 Set an upper bound on the number of transient objects that each client
 connection allowed to load. Once this number of objects is reached attempts
 to load new transient objects will produce an error.

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -158,7 +158,7 @@ init_thread_func (gpointer user_data)
         IPC_FRONTEND (ipc_frontend_dbus_new (data->options.bus,
                                              data->options.dbus_name,
                                              connection_manager,
-                                             data->options.max_transient_objects,
+                                             data->options.max_transients,
                                              data->random));
     if (data->ipc_frontend == NULL) {
         g_error ("failed to allocate IpcFrontend object");
@@ -365,8 +365,8 @@ parse_opts (gint            argc,
         { "max-sessions", 'e', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
           &options->max_sessions,
           "Maximum number of sessions per connection.", NULL },
-        { "max-transient-objects", 'r', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
-          &options->max_transient_objects,
+        { "max-transients", 'r', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
+          &options->max_transients,
           "Maximum number of loaded transient objects per client.", NULL },
         { "prng-seed-file", 'g', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING,
           &options->prng_seed_file, "File to read seed value for PRNG",
@@ -410,8 +410,8 @@ parse_opts (gint            argc,
         tabrmd_critical ("max-sessions must be between 1 and %d",
                          TABRMD_SESSIONS_MAX_DEFAULT);
     }
-    if (options->max_transient_objects < 1 ||
-        options->max_transient_objects > TABRMD_TRANSIENT_MAX)
+    if (options->max_transients < 1 ||
+        options->max_transients > TABRMD_TRANSIENT_MAX)
     {
         tabrmd_critical ("max-trans-obj parameter must be between 1 and %d",
                          TABRMD_TRANSIENT_MAX);

--- a/src/tabrmd.h
+++ b/src/tabrmd.h
@@ -66,7 +66,7 @@
     .bus = (GBusType)TABRMD_DBUS_TYPE_DEFAULT, \
     .flush_all = FALSE, \
     .max_connections = TABRMD_CONNECTIONS_MAX_DEFAULT, \
-    .max_transient_objects = TABRMD_TRANSIENT_MAX_DEFAULT, \
+    .max_transients = TABRMD_TRANSIENT_MAX_DEFAULT, \
     .max_sessions = TABRMD_SESSIONS_MAX_DEFAULT, \
     .dbus_name = TABRMD_DBUS_NAME_DEFAULT, \
     .prng_seed_file = TABRMD_ENTROPY_SRC_DEFAULT, \
@@ -79,7 +79,7 @@ typedef struct tabrmd_options {
     GBusType        bus;
     gboolean        flush_all;
     guint           max_connections;
-    guint           max_transient_objects;
+    guint           max_transients;
     guint           max_sessions;
     gchar          *dbus_name;
     const gchar    *prng_seed_file;


### PR DESCRIPTION
This gets us a bit more consistency with the other 'max-sessions' and
'max-connections' options. Update the man page and the CHANGELOG.md as
well.

This resolves #457 

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>