### PR TITLE
Add scan-build Static Code Analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,12 @@ script :
   - echo 'Configuring source code...' && echo -en 'travis_fold:start:tabrmd-configure\\r'
   - |
     CONFIGURE_OPTIONS="--disable-dlclose --enable-unit --enable-integration"
+    if [[ "$CC" == clang* ]]; then
+        # Use -D_REENTRANT kludge so -pthread test works with scan-build:
+        scan-build ./configure CFLAGS="$CFLAGS -D_REENTRANT" $CONFIGURE_OPTIONS
+        dbus-launch scan-build --status-bugs make -j$(nproc) distcheck
+        make clean
+    fi
     if [ "$CC" = "gcc" ]; then
         CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --enable-code-coverage"
     fi


### PR DESCRIPTION
Run clang scan-build static code analysis.
Run scan-build separately as scan-build returns a separate exit status
from make depending on whether static analysis passed or failed.

Fixes #428.

Signed-off-by: Dan Anderson <daniel.anderson@intel.com>