### PR TITLE
test: Fix test on per-connection limits to session loading.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,8 +68,7 @@ TESTS_INTEGRATION_NOHW = test/integration/tcti-connect-multiple.int
 
 TESTS = $(TESTS_INTEGRATION)
 XFAIL_TESTS = \
-    test/integration/start-auth-session.int \
-    test/integration/auth-session-max.int
+    test/integration/start-auth-session.int
 TEST_EXTENSIONS = .int
 AM_TESTS_ENVIRONMENT = \
     TEST_FUNC_LIB=$(srcdir)/scripts/int-test-funcs.sh \

--- a/test/integration/auth-session-max.int.c
+++ b/test/integration/auth-session-max.int.c
@@ -31,10 +31,10 @@
 #include <tss2/tss2_tpm2_types.h>
 
 #include "common.h"
+#include "tabrmd.h"
 #include "test.h"
+
 #define PRIxHANDLE "08" PRIx32
-#define SESSIONS_MAX 4
-#define SESSIONS_TRY 5
 /*
  * This test exercises the session creation logic. We begin by creating the
  * most simple session we can. We then save it. When this test terminates
@@ -44,25 +44,30 @@ int
 test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 {
     TSS2_RC               rc;
-    TPMI_SH_AUTH_SESSION  session_handle [SESSIONS_TRY] = { 0 };
+    TPMI_SH_AUTH_SESSION  session_handle [TABRMD_SESSIONS_MAX_DEFAULT + 1] = { 0 };
     size_t i;
 
-    for (i = 0; i < SESSIONS_TRY; ++i) {
+    for (i = 0; i < TABRMD_SESSIONS_MAX_DEFAULT + 1; ++i) {
         /* create an auth session */
         g_info ("Starting unbound, unsalted auth session");
         rc = start_auth_session (sapi_context, &session_handle [i]);
+        if (rc == TSS2_RESMGR_RC_SESSION_MEMORY &&
+            i == TABRMD_SESSIONS_MAX_DEFAULT) {
+            g_info ("Tss2_Sys_StartAuthSession failed: 0x%" PRIxHANDLE
+                    " trying to create session #%zd", rc, i + 1);
+            return 0;
+        }
         if (rc != TSS2_RC_SUCCESS) {
-            g_debug ("Tss2_Sys_StartAuthSession failed: 0x%" PRIxHANDLE, rc);
-            break;
+            g_critical ("Got unexpected response code: 0x%" PRIxHANDLE, rc);
+            return 1;
         }
         g_info ("StartAuthSession for TPM_SE_POLICY success! Session handle: "
                 "0x%08" PRIx32, session_handle [i]);
     }
-    g_debug ("i == %zu", i);
-    if (i + 1 == SESSIONS_MAX) {
-        return 0;
-    } else {
-        g_critical ("expected to create %d sessions, created %zd instead", SESSIONS_MAX, i + 1);
-        return 1;
-    }
+    /*
+     * this test should never get here. An error should be caught in the loop
+     * above which is what we want. If execution reaches this point in the
+     * function then the upper bound isn't working properly
+     */
+    return 1;
 }


### PR DESCRIPTION
The logic in the daemon works as expected. This test was just poorly
written. The logic in the test has been sorted out. It's also now using
the constants from the daemons header to determine the default upper
bound and testing accordingly.

this resolves #459 

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>