### PR TITLE
tcti-util: Use proper SONAME for TCTI dlopen.

### DIFF
--- a/src/tcti-util.c
+++ b/src/tcti-util.c
@@ -53,7 +53,7 @@ tcti_util_discover_info (const char *filename,
     if (*tcti_dl_handle == NULL) {
         size = snprintf (filename_xfrm,
                          sizeof (filename_xfrm),
-                         "libtss2-tcti-%s.so",
+                         "libtss2-tcti-%s.so.0",
                          filename);
         if (size >= sizeof (filename_xfrm)) {
             g_critical ("TCTI name truncated in transform.");


### PR DESCRIPTION
This resolves a bug reported on the mailing list:
https://lists.01.org/pipermail/tpm2/2018-May/000700.html

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>