### PR TITLE
build: Ignore 'core' files as workaround for weird travis-ci stuff.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -149,6 +149,7 @@ CLEANFILES = \
     $(systemdsystemunit_DATA) \
     test/integration/*.log \
     _tabrmd.log
+DISTCLEANFILES = core
 
 BUILT_SOURCES = src/tabrmd-generated.h src/tabrmd-generated.c
 


### PR DESCRIPTION
I can't explain why yet but when `distcheck` runs on travis-ci it fails
roughly 50% of the time when executing distcheck. This failure is caused
by a 'core' file that is presumably left behind by a test program. Odly
enough this should also cause the test harness to report a failure. But
since I'm unable to reproduce locally debugging is cumbersome.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>