### PR TITLE
Remove GNU-libc-specific header

### DIFF
--- a/src/connection-manager.c
+++ b/src/connection-manager.c
@@ -25,7 +25,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include <errno.h>
-#include <error.h>
 #include <glib.h>
 #include <inttypes.h>
 #include <pthread.h>


### PR DESCRIPTION
musl libc does not contain 'error.h' which results in compile-time errors in Alpine containers. I believe 'error.h' is specific to GNU libc. Removing the include statement does not appear to cause any problems and allows the build to get further in Alpine.