### PR TITLE
SessionList: Remove _lookup_connection function.

### DIFF
--- a/src/session-list.c
+++ b/src/session-list.c
@@ -383,30 +383,6 @@ session_list_remove_last (SessionList *list)
 /*
  * This is a lookup function to find an entry in the SessionList given
  * handle. The caller *must* hold the lock on the SessionList. Further they
- * must hold this lock until they are done with the SessionEntry
- * returned. This function increases the reference count on the SessionEntry
- * returned. The caller must decrement the reference count when it is done
- * with the entry.
- */
-SessionEntry*
-session_list_lookup_connection (SessionList   *list,
-                                Connection    *connection)
-{
-    GList *list_entry;
-
-    list_entry = g_list_find_custom (list->session_entry_list,
-                                      connection,
-                                      session_entry_compare_on_connection);
-    if (list_entry != NULL) {
-        g_object_ref (list_entry->data);
-        return SESSION_ENTRY (list_entry->data);
-    } else {
-        return NULL;
-    }
-}
-/*
- * This is a lookup function to find an entry in the SessionList given
- * handle. The caller *must* hold the lock on the SessionList. Further they
  * must hold this lock until they are done with the SessionListEntry
  * returned. This function increases the reference count on the
  * SessionEntry returned. The caller must decrement the reference count

--- a/src/session-list.h
+++ b/src/session-list.h
@@ -64,8 +64,6 @@ gboolean       session_list_insert            (SessionList      *list,
                                                SessionEntry     *entry);
 gint           session_list_lock              (SessionList      *list);
 gint           session_list_unlock            (SessionList      *list);
-SessionEntry*  session_list_lookup_connection (SessionList      *list,
-                                               Connection       *connection);
 SessionEntry*  session_list_lookup_handle     (SessionList      *list,
                                               TPM2_HANDLE        handle);
 gint           session_list_remove_handle     (SessionList      *list,


### PR DESCRIPTION
This function looks identical to the _lookup_handle function but it
behaves very differently. This inconsistency is annoying and the
function itself is awkward. The same functionality can be achieved by
using the current foreach iterator. This produces an extra layer of
indirection when processing closed connections but it's a small price to
pay to get rid of a bad function.

Signed-off-by: Philip Tricca <flihp@twobit.org>