### PR TITLE
test: Work around scan-build false positive with simple assert.

### DIFF
--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <assert.h>
 #include <glib.h>
 #include <inttypes.h>
 #include <unistd.h>
@@ -378,7 +379,9 @@ resource_manager_load_handles_test(void **state)
 
     tpm2_command_get_handles (data->command, vhandles, &handle_count);
     map = connection_get_trans_map (data->connection);
-    assert_true (handle_count <= 2);
+    if (handle_count > 2) {
+        assert (FALSE);
+    }
     for (i = 0; i < handle_count; ++i) {
         entry = handle_map_entry_new (phandles [i], vhandles [i]);
         handle_map_insert (map, vhandles [i], entry);


### PR DESCRIPTION
scan-build doesn't understand the cmocka asserts. Without this patch
it logs a false positive:

test/resource-manager_unit.c:383:17: warning: 1st function call argument is an uninitialized value
        entry = handle_map_entry_new (phandles [i], vhandles [i]);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.

As a work-around we can use a conditional and a standard 'assert' which
scan-build understands just fine. There's probably a more elegant way
to inform scan-build about the cmocka asserts but I haven't found anything
concrete yet.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>