### PR TITLE
Ci cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,18 +86,27 @@ script :
     fi
   - |
     CONFIGURE_OPTIONS="--disable-dlclose --enable-unit --enable-integration"
-    if [[ "$CC" == clang* ]]; then
+    case "$CC" in
+    clang*)
         # Use -D_REENTRANT kludge so -pthread test works with scan-build:
         scan-build ./configure CFLAGS="$CFLAGS -D_REENTRANT" $CONFIGURE_OPTIONS
         dbus-launch scan-build --status-bugs make -j$(nproc) distcheck
-        make clean
-    fi
-    if [ "$CC" = "gcc" ]; then
-        CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --enable-code-coverage"
-    fi
-    ./configure ${CONFIGURE_OPTIONS}
-  - dbus-launch make -j$(nproc) distcheck
-  - dbus-launch make -j$(nproc) check-code-coverage
+        # exit code from scan-build is 0 if no bugs are found, failed tests
+        # will go undetected unless we manually parse the test log for:
+        # '# FAIL:  0'
+        TEST_LOG=$(find ./tpm2-abrmd-*/_build -name 'test-suite.log')
+        if [ -f "${TEST_LOG}" ]; then
+            grep '^#[[:space:]]\+FAIL:[[:space:]]\+0$' ${TEST_LOG}
+        fi
+        ;;
+    gcc)
+        ./configure ${CONFIGURE_OPTIONS} --enable-code-coverage
+        dbus-launch make -j$(nproc) distcheck
+        ;;
+    *)
+        echo "unsupported compiler"
+        exit 1
+    esac
   - |
     if [ \( "$CC" = "gcc" \) -a \( ! -z "$COVERALLS_REPO_TOKEN" \) ]; then
         coveralls --build-root=./ --exclude=${DEPS} --exclude=${DESTDIR} --exclude=./test --exclude=tpm2-abrmd-$(cat VERSION) --exclude=./coverity --exclude=./src/tabrmd-generated.c --exclude=./src/tabrmd-generated.h --gcov-options '\-lp'

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,9 +102,16 @@ script :
     if [ \( "$CC" = "gcc" \) -a \( ! -z "$COVERALLS_REPO_TOKEN" \) ]; then
         coveralls --build-root=./ --exclude=${DEPS} --exclude=${DESTDIR} --exclude=./test --exclude=tpm2-abrmd-$(cat VERSION) --exclude=./coverity --exclude=./src/tabrmd-generated.c --exclude=./src/tabrmd-generated.h --gcov-options '\-lp'
     fi
+
+after_failure:
   - |
-    cat test-suite*.log
-    for LOG in $(ls -1 test/*.log); do
-        echo "${LOG}"
+    TEST_ROOT=tpm2-abrmd-*/_build
+    # newer versions of automake have distcheck output under a new directory
+    if [ -d ${TEST_ROOT}/sub ]; then
+        TEST_ROOT=${TEST_ROOT}/sub
+    fi
+    cat ${TEST_ROOT}/test-suite.log
+    find ${TEST_ROOT}/test -name '*.log' | while read LOG; do
+        echo "dumping test log: ${LOG}"
         cat ${LOG}
     done


### PR DESCRIPTION
While debugging #490 it became plane that the current CI script needed some cleanup. Part of this was motivated by the need to just getting meaningful output from the test harness logs when a test fails. While doing this I realized that the CI configuration was also ignoring the results from scan-build which was suppressing a finding from the tool (granted it was a false positive). These two patches fix the issue of the logs remaining invisible when a test fails as well as treating findings from scan-build as failures. 

I've also rolled in some efficiency gains by removing unnecessary build steps that we were using as a crutch. Removing these steps reduces our build time (as reported by travis-ci) from ~12 minutes to ~9 which is pretty significant.