### PR TITLE
SessionList: Fix Connection object reference leak.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a CHANGELOG](http://keepachangelog.com/)
 - Default shared object name for dynamic TCTI loading now includes major
 version number suffix.
 - Race condition in between session mgmt and connection teardown logic.
+- Leaked references to Connection objects in SessionList when calculating
+the number of sessions belonging to a Connection.
 
 ## 2.0.0 - 2018-06-22
 ### Added

--- a/src/session-list.c
+++ b/src/session-list.c
@@ -436,11 +436,13 @@ session_list_connection_counter (gpointer data,
                                  gpointer user_data)
 {
     SessionEntry *entry = SESSION_ENTRY (data);
+    Connection *conn = session_entry_get_connection (entry);
     connection_count_data_t *count_data = (connection_count_data_t*)user_data;
 
-    if (count_data->connection == session_entry_get_connection (entry)) {
+    if (count_data->connection == conn) {
         ++count_data->count;
     }
+    g_clear_object (&conn);
 }
 /*
  * Returns the number of entries associated with the provided connection.


### PR DESCRIPTION
When iterating SessionEntry objects to count the number of sessions
belonging to a Connection the callback was taking references to the
Connection object but not releasing them. This commit adds the
missing call to decrement the reference count.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>