### PR TITLE
Remove TEMP_FAILURE_RETRY call for portability

### DIFF
--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -165,7 +165,7 @@ tcti_tabrmd_poll (int        fd,
     int ret;
     int errno_tmp;
 
-    ret = TEMP_FAILURE_RETRY (poll (pollfds,
+    ret = TABRMD_ERRNO_EINTR_RETRY (poll (pollfds,
                                     sizeof (pollfds) / sizeof (struct pollfd),
                                     timeout));
     errno_tmp = errno;

--- a/src/util.h
+++ b/src/util.h
@@ -46,6 +46,19 @@
 #define ASSERT_NON_NULL(x) assert_non_null(x)
 #endif
 
+/*
+ * Substitute  for GNU TEMP_FAILURE_RETRY for environments that
+ * don't have the GNU C library.
+ */
+#define TABRMD_ERRNO_EINTR_RETRY(exp)                   \
+  ({                                                    \
+    long int __result = 0;                              \
+    do {                                                \
+      __result = (long int)(exp);                       \
+    } while ((__result == -1) && (errno == EINTR));     \
+    __result;                                           \
+  })
+
 /* set the layer / component to indicate the RC comes from the RM */
 #define RM_RC(rc) TSS2_RESMGR_RC_LAYER + rc
 


### PR DESCRIPTION
TEMP_FAILURE_RETRY is a non-protable extension to GNU libc.

This PR replaces it with implementation similar to TSS2_RETRY_EXP in
tpm2-tss, but consistent with behaviour described in the GNU C library manual:
  https://www.gnu.org/software/libc/manual/html_node/Interrupted-Primitives.html

Adressing issue https://github.com/tpm2-software/tpm2-abrmd/issues/475
