### PR TITLE
ci: Build 'check' target when CC is gcc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,16 +101,15 @@ script :
         ;;
     gcc)
         ./configure ${CONFIGURE_OPTIONS} --enable-code-coverage
-        dbus-launch make -j$(nproc) distcheck
+        dbus-launch make -j$(nproc) check
+        if [ ! -z "$COVERALLS_REPO_TOKEN" ]; then
+          coveralls --build-root=./ --exclude=${DEPS} --exclude=${DESTDIR} --exclude=./test --exclude=tpm2-abrmd-$(cat VERSION) --exclude=./coverity --exclude=./src/tabrmd-generated.c --exclude=./src/tabrmd-generated.h --gcov-options '\-lp'
+        fi
         ;;
     *)
         echo "unsupported compiler"
         exit 1
     esac
-  - |
-    if [ \( "$CC" = "gcc" \) -a \( ! -z "$COVERALLS_REPO_TOKEN" \) ]; then
-        coveralls --build-root=./ --exclude=${DEPS} --exclude=${DESTDIR} --exclude=./test --exclude=tpm2-abrmd-$(cat VERSION) --exclude=./coverity --exclude=./src/tabrmd-generated.c --exclude=./src/tabrmd-generated.h --gcov-options '\-lp'
-    fi
 
 after_failure:
   - |


### PR DESCRIPTION
This is to collect code coverage metrics. The distcheck target will
clean up after itself and delete these. We still execute distcheck for
clang builds, now for gcc we build the 'check' target so that the test
coverage metrics can be sent to coveralls and we don't incur the cost
of two builds.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>