### PR TITLE
build: Fix bad URLs in configure script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ version number suffix.
 - Race condition in between session mgmt and connection teardown logic.
 - Leaked references to Connection objects in SessionList when calculating
 the number of sessions belonging to a Connection.
+- Replace old '01org' URLs in configure script.
 
 ## 2.0.0 - 2018-06-22
 ### Added

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 AC_INIT([tpm2-abrmd],
         [m4_esyscmd_s([cat ./VERSION])],
-        [https://github.com/01org/tpm2-abrmd/issues],
+        [https://github.com/tpm2-software/tpm2-abrmd/issues],
         [],
-        [https://github.com/01org/tpm2-abrmd])
+        [https://github.com/tpm2-software/tpm2-abrmd])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 AC_PROG_LN_S


### PR DESCRIPTION
This fix updates the URLs to our new github organization. We migrated
away from the 01org github org some time back but these were never
update. Github redirects for us so the old URLs will still bring people
to the right place. Fixing these up is just good housekeeping.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>