### PR TITLE
util: fix a format warning that can occur on some platforms

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -98,7 +98,7 @@ write_all (GOutputStream *ostream,
         g_debug ("writing %zu bytes starting at 0x%" PRIxPTR " to socket 0x%"
                  PRIxPTR,
                  size - written_total,
-                 (uintptr_t)buf + written_total,
+                 (uintptr_t)(buf + written_total),
                  (uintptr_t)socket);
         written = g_output_stream_write (ostream,
                                          (const gchar*)&buf [written_total],


### PR DESCRIPTION
When building for the s390 architecture the following warning occurs
which leads to a build error:

```
src/util.c: In function 'write_all':
src/util.c:100:9: error: format '%x' expects argument of type 'unsigned int', but argument 5 has type 'long unsigned int' [-Werror=format=]
         g_debug ("writing %zu bytes starting at 0x%" PRIxPTR " to socket 0x%"
         ^
```

size_t is of a different type than uintptr_t on s390. Due do integer
type promotion the type won't match the PRIxPTR specifier any more after
adding to it.

Arithmetic should be done with the pointer, not the uintptr_t. This will
fix will the warning.

Signed-off-by: Matthias Gerstner <matthias.gerstner@suse.de>