### PR TITLE
build: Cleanup logic enabling test cases based on configuration options.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,14 +78,15 @@ AM_TESTS_ENVIRONMENT = \
 INT_LOG_COMPILER = $(srcdir)/scripts/int-test-setup.sh
 INT_LOG_FLAGS = --tabrmd-tcti=$(TABRMD_TCTI)
 
+if ENABLE_INTEGRATION
+noinst_LTLIBRARIES += $(libtest)
+TESTS += $(TESTS_INTEGRATION)
 if HWTPM
 TABRMD_TCTI = device
-endif
-
-if ENABLE_INTEGRATION
+else
 TABRMD_TCTI = mssim
-noinst_LTLIBRARIES += $(libtest)
-TESTS += $(TESTS_INTEGRATION) $(TESTS_INTEGRATION_NOHW)
+TESTS += $(TESTS_INTEGRATION_NOHW)
+endif
 endif
 
 if UNIT


### PR DESCRIPTION
The configure script will set ENABLE_INTEGRATION if the integration
tests should be run (--enable-integration). HWTPM is set if the
integration tests are to be run against the hardware TPM instead of the
simulator. These two conditionals are a bit tangled in that we only care
about HWTPM if ENABLE_INTEGRATION has been set as HWTPM will only be set
if ENABLE_INTEGRATION has been set as well.

This patch moves the HWTPM checks so that they are only in the scope of
the ENABLE_INTEGRATION block.

Fixes #518 

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>