### PR TITLE
util: Fix sign of format specifier in debug message.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -155,7 +155,7 @@ read_data (GInputStream  *istream,
 
     g_assert (index != NULL);
     do {
-        g_debug ("reading %zd bytes socket 0x%" PRIxPTR", to 0x%" PRIxPTR,
+        g_debug ("reading %zu bytes socket 0x%" PRIxPTR", to 0x%" PRIxPTR,
                  bytes_left, (uintptr_t)socket, (uintptr_t)&buf [*index]);
         num_read = g_input_stream_read (istream,
                                         (gchar*)&buf [*index],


### PR DESCRIPTION
The value being printed is unsigned but the conversion specifier zd is
used. zd is for signed sizes (aka ssize_t).

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>