### PR TITLE
tcti: Initialize TCTI context to 0 before setting defaults.

### DIFF
--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -390,6 +390,8 @@ tss2_tcti_tabrmd_set_locality (TSS2_TCTI_CONTEXT *context,
 void
 init_tcti_data (TSS2_TCTI_CONTEXT *context)
 {
+    memset (context, 0, sizeof (TSS2_TCTI_TABRMD_CONTEXT));
+
     TSS2_TCTI_MAGIC (context)            = TSS2_TCTI_TABRMD_MAGIC;
     TSS2_TCTI_VERSION (context)          = TSS2_TCTI_TABRMD_VERSION;
     TSS2_TCTI_TABRMD_STATE (context)     = TABRMD_STATE_TRANSMIT;


### PR DESCRIPTION
This patch sets all fields in the context that aren't explicitly set to
0.

This resolves #514

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>