### PR TITLE
Fix gdbus-codegen lookup for recent versions of GLib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ PKG_CHECK_MODULES([GLIB], [glib-2.0])
 PKG_CHECK_MODULES([GOBJECT], [gobject-2.0])
 PKG_CHECK_MODULES([TSS2_SYS],[tss2-sys >= 2.0.0])
 AC_ARG_VAR([GDBUS_CODEGEN],[The gdbus-codegen executable.])
-AC_PATH_PROG([GDBUS_CODEGEN], [`$PKG_CONFIG --variable=gdbus_codegen gio-2.0`])
+AC_PATH_PROG([GDBUS_CODEGEN], [gdbus-codegen])
 if test -z "$GDBUS_CODEGEN"; then
     AC_MSG_ERROR([*** gdbus-codegen is required to build tpm2-abrmd])
 fi


### PR DESCRIPTION
When trying to compile tpm2-abrmd using a GLib version built using the Meson build system (e.g. the most recent [glib2 2.58.0-1 for Arch Linux](https://www.archlinux.org/packages/core/x86_64/glib2/)), the build fails with the error

    checking for /usr/bin/gdbus-codegen... no
    configure: error: *** gdbus-codegen is required to build tpm2-abrmd

The reason for this is that the [check in the configure script](https://github.com/tpm2-software/tpm2-abrmd/blob/d0120ace58d97bc9520c0d558657eaca87ae73b1/configure.ac#L42) relies on the `gdbus_codegen` variable from the GLib pkg-config file. For the Meson build, the value of this variable [has been changed](https://gitlab.gnome.org/GNOME/glib/issues/1521) from just the binary name `gdbus-codegen` to a full path, e.g. `/usr/bin/gdbus-codegen`, which does not work with `AC_PATH_PROG` from Autotools.

According to [one of the GLib maintainers](https://gitlab.gnome.org/GNOME/glib/issues/1521#note_313402), the recommended way to solve this is to look up `gdbus-codegen` directly on the PATH without using the pkg-config variable, which is what this pull request does. It works both with old and new versions of GLib as it eliminates the use of this variable completely.