### PR TITLE
travis.yml: Existence of build directory indicates build failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,12 +96,11 @@ script :
         # exit code from scan-build is 0 if no bugs are found, failed tests
         # will go undetected unless we manually parse the test log for:
         # '# FAIL:  0'
+        TEST_LOG_DIR=$(find ./tpm2-abrmd-* -name '_build')
+        if [ -d "${TEST_LOG_DIR}" ]; then exit 1; fi
         TEST_LOG=$(find ./tpm2-abrmd-*/_build -name 'test-suite.log')
         if [ -f "${TEST_LOG}" ]; then
             grep '^#[[:space:]]\+FAIL:[[:space:]]\+0$' ${TEST_LOG}
-        else
-            # if there's no 'test-suite.log' file the build failed
-            exit 1
         fi
         ;;
     gcc)


### PR DESCRIPTION
scan-build makes this a bit complex but it's not too bad. This fixes a
bug in the logic used previously that fails the build if the test log
file isn't available. This naively assumption doesn't account for the
fact that a successful build will have removed this file by the time we
check. Instead we should fail if the build directory exists. The build
won't remove the build directory if the build fails so we can debug
stuff.

this fixes more stuff related to #536 

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>