### PR TITLE
test: Placate scan-build with an assert to fix the Random unit test.

### DIFF
--- a/src/random.c
+++ b/src/random.c
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <string.h>
@@ -149,6 +150,7 @@ random_get_bytes (Random    *random,
 
     g_debug ("random_get_bytes: %p", random);
     g_assert_nonnull (random);
+    assert (random->rand_state);
     for (i = 0; i < count; ++i) {
         *(&rand[0]) = nrand48 (random->rand_state);
         memcpy (&dest[i], &rand[0], sizeof (uint8_t));


### PR DESCRIPTION
We couldn't use g_assert_nonnull here since clang doesn't recognize this
as an assert. We need to look into using the GNOME scan-build wrapper.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>