### PR TITLE
Handle ContextSave and ContextLoad operations for sessions.

### DIFF
--- a/src/access-broker.c
+++ b/src/access-broker.c
@@ -496,7 +496,7 @@ access_broker_send_command (AccessBroker  *broker,
     g_debug ("access_broker_send_command: AccessBroker: 0x%" PRIxPTR
              " Tpm2Response: 0x%" PRIxPTR " RC: 0x%" PRIx32, (uintptr_t)broker,
              (uintptr_t)response, tpm2_response_get_code (response));
-    g_object_unref (connection);
+    g_clear_object (&connection);
     return response;
 
 unlock_out:

--- a/src/session-entry.h
+++ b/src/session-entry.h
@@ -36,6 +36,13 @@
 
 G_BEGIN_DECLS
 
+#define SIZE_BUF_MAX sizeof (TPMS_CONTEXT)
+
+typedef struct size_buf {
+    size_t size;
+    uint8_t buf [SIZE_BUF_MAX];
+} size_buf_t;
+
 typedef struct _SessionEntryClass {
     GObjectClass      parent;
 } SessionEntryClass;
@@ -44,7 +51,9 @@ typedef struct _SessionEntry {
     GObject                parent_instance;
     Connection            *connection;
     SessionEntryStateEnum  state;
-    TPMS_CONTEXT           context;
+    TPM2_HANDLE            handle;
+    size_buf_t             context;
+    size_buf_t             context_client;
 } SessionEntry;
 
 #define TYPE_SESSION_ENTRY              (session_entry_get_type   ())
@@ -57,12 +66,17 @@ typedef struct _SessionEntry {
 GType            session_entry_get_type        (void);
 SessionEntry*    session_entry_new             (Connection        *connection,
                                                 TPM2_HANDLE         handle);
+size_buf_t*      session_entry_get_context_client (SessionEntry *entry);
 Connection*      session_entry_get_connection  (SessionEntry      *entry);
 TPM2_HANDLE       session_entry_get_handle      (SessionEntry      *entry);
-TPMS_CONTEXT*    session_entry_get_context     (SessionEntry      *entry);
+size_buf_t*      session_entry_get_context     (SessionEntry      *entry);
+void             session_entry_set_context     (SessionEntry      *entry,
+                                                uint8_t           *buf,
+                                                size_t             size);
 SessionEntryStateEnum session_entry_get_state  (SessionEntry      *entry);
 void             session_entry_set_connection  (SessionEntry      *entry,
                                                 Connection        *connection);
+void session_entry_clear_connection (SessionEntry *entry);
 void             session_entry_set_state       (SessionEntry      *entry,
                                                 SessionEntryStateEnum state);
 void             session_entry_prettyprint     (SessionEntry      *entry);
@@ -72,6 +86,9 @@ gint session_entry_compare_on_connection (gconstpointer a,
                                           gconstpointer b);
 gint session_entry_compare_on_handle (gconstpointer a,
                                       gconstpointer b);
+gint session_entry_compare_on_context_client (SessionEntry *entry,
+                                              uint8_t *buf,
+                                              size_t size);
 void session_entry_abandon (SessionEntry *entry);
 
 G_END_DECLS

--- a/src/session-list.h
+++ b/src/session-list.h
@@ -71,6 +71,9 @@ gboolean       session_list_insert            (SessionList      *list,
                                                SessionEntry     *entry);
 SessionEntry*  session_list_lookup_handle     (SessionList      *list,
                                               TPM2_HANDLE        handle);
+SessionEntry*  session_list_lookup_context_client (SessionList *list,
+                                                   uint8_t     *buf,
+                                                   size_t       size);
 gint           session_list_remove_handle     (SessionList      *list,
                                                TPM2_HANDLE        handle);
 gint           session_list_remove_connection (SessionList      *list,

--- a/src/tpm2-command.h
+++ b/src/tpm2-command.h
@@ -62,6 +62,9 @@ Tpm2Command*          tpm2_command_new             (Connection      *connection,
                                                     guint8           *buffer,
                                                     size_t            size,
                                                     TPMA_CC           attrs);
+Tpm2Command*          tpm2_command_new_context_save (TPM2_HANDLE);
+Tpm2Command*          tpm2_command_new_context_load (uint8_t *buf,
+                                                     size_t size);
 TPMA_CC               tpm2_command_get_attributes  (Tpm2Command      *command);
 TPMA_SESSION          tpm2_command_get_auth_attrs  (Tpm2Command      *command,
                                                     size_t            auth_offset);

--- a/src/tpm2-header.h
+++ b/src/tpm2-header.h
@@ -56,5 +56,10 @@ void                   set_response_size      (uint8_t      *response_header,
 TSS2_RC                get_response_code      (uint8_t      *response_header);
 void                   set_response_code      (uint8_t      *response_header,
                                                TSS2_RC       rc);
+TSS2_RC                tpm2_header_init       (uint8_t      *buf,
+                                               size_t        buf_size,
+                                               TPM2_ST       tag,
+                                               UINT32        size,
+                                               TSS2_RC       code);
 
 #endif /* TPM2_HEADER_H */

--- a/src/tpm2-response.h
+++ b/src/tpm2-response.h
@@ -31,6 +31,7 @@
 #include <tss2/tss2_tpm2_types.h>
 
 #include "connection.h"
+#include "session-entry.h"
 
 G_BEGIN_DECLS
 
@@ -62,6 +63,10 @@ Tpm2Response*       tpm2_response_new           (Connection      *connection,
                                                  TPMA_CC          attributes);
 Tpm2Response*       tpm2_response_new_rc        (Connection      *connection,
                                                  TSS2_RC           rc);
+Tpm2Response* tpm2_response_new_context_save (Connection *connection,
+                                              SessionEntry *entry);
+Tpm2Response* tpm2_response_new_context_load (Connection *connection,
+                                              SessionEntry *entry);
 TPMA_CC             tpm2_response_get_attributes (Tpm2Response   *response);
 guint8*             tpm2_response_get_buffer    (Tpm2Response    *response);
 TSS2_RC              tpm2_response_get_code      (Tpm2Response    *response);

--- a/test/session-entry_unit.c
+++ b/test/session-entry_unit.c
@@ -43,7 +43,10 @@ typedef struct {
     SessionEntry *session_entry;
 } test_data_t;
 /*
- * Setup function
+ * Setup function:
+ * Creates a structure to hold test data.
+ * Creates supporting objects for tests: HandleMap, IOStream, Connection.
+ * Creates a SessionEntry (the object under test).
  */
 static int
 session_entry_setup (void **state)
@@ -99,10 +102,10 @@ static void
 session_entry_get_context_test (void **state)
 {
     test_data_t *data = (test_data_t*)*state;
+    size_buf_t *size_buf;
 
-    TPMS_CONTEXT *context = NULL;
-    context = session_entry_get_context (data->session_entry);
-    assert_non_null (context);
+    size_buf = session_entry_get_context (data->session_entry);
+    assert_non_null (size_buf);
 }
 
 static void


### PR DESCRIPTION
This commit contains structural changes that are required for handling
the context gap response code. The previous approach was as passive as
possible when it came to handling sessions. The ResourceManager passed
all ContextSave and ContextLoad commands through to the TPM and
extracting the data it needed from them as they passed. This data was
sufficient for us to load and save contexts when clients referenced them
in the handle / auth area of a command.

This design works so long as we don't need to load / save a session
context in between a ContextSave & ContextLoad from the Connection that
owns it. We previously worked around this by refusing to do this. This
was fine since the TPM throws errors if it receives a command that
references sessions that aren't loaded and we were just preserving this
behavior.

This design falls down if we ever encounter a situation in which we
*must* break the rules described above. Handling the context gap is
exactly this situation. This commit changes this design as follows:

SessionEntry: This is where we store the context object when it's saved.
We now maintain two copies of the context object. The first is the copy
that the ResourceManager uses, the second is the one that we expose to
the client. These TPMS_CONTEXT structures are stored in their marshalled
form. We also add a few utility functions to make handling these blobs
easier.

tpm2-header: This commit adds a convenience function to this module for
setting the header fields in a memory blob. This is very useful when
we're constructing response buffers to send back to the caller on behalf
of the TPM.

Tpm2Command: We've added two new functions to create TPM2_ContextLoad
and TPM2_ContextSave commands. Now that we're storing the TPMS_CONTEXT
structures as marshalled blobs we use a different interface in the
AccessBroker to send Tpm2Command objects that we generate manually.

Tpm2Response: We've added two new functions to create Tpm2Response
objects suitable for responding to clients executing the
TPM2_ContextSave and TPM2_ContextLoad commands. This includes creating
the response buffer body from the TPM_CONTEXT structure / handle where
appropriate.

SessionList: This object needded a way to lookup SessionEntry objects
based on the provided context blob. This uses comparison mechanisms
added to the SessionEntry object.

ResourceManager: The changes above allow us to handle a.k.a.
"virtualize" the ContextSave and ContextLoad operations for sessions.
This required a lot of refactoring and some new code to intercept these
commands and generate an appropriate response. All code associated with
transferring session ownership has been relocated to these functions.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>