### PR TITLE
Fork tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,9 @@ TESTS_INTEGRATION = \
     test/integration/auth-session-start-flush.int \
     test/integration/auth-session-start-save.int \
     test/integration/auth-session-start-save-load.int \
+    test/integration/fork-proxy.int \
+    test/integration/fork-proxy-new-for-bus.int \
+    test/integration/fork-proxy-connection-unique.int \
     test/integration/fork-tcti-create-after.int \
     test/integration/fork-tcti-parent-before-child-after.int \
     test/integration/max-transient-upperbound.int \
@@ -462,6 +465,18 @@ test_integration_auth_session_start_save_int_SOURCES = test/integration/main.c \
 test_integration_auth_session_start_save_load_int_LDADD = $(TEST_INT_LIBS)
 test_integration_auth_session_start_save_load_int_SOURCES = test/integration/main.c \
     test/integration/auth-session-start-save-load.int.c
+
+test_integration_fork_proxy_int_LDADD = $(TEST_INT_LIBS)
+test_integration_fork_proxy_int_SOURCES = \
+    test/integration/fork-proxy.int.c
+
+test_integration_fork_proxy_new_for_bus_int_LDADD = $(TEST_INT_LIBS)
+test_integration_fork_proxy_new_for_bus_int_SOURCES = \
+    test/integration/fork-proxy-new-for-bus.int.c
+
+test_integration_fork_proxy_connection_unique_int_LDADD = $(TEST_INT_LIBS)
+test_integration_fork_proxy_connection_unique_int_SOURCES = \
+    test/integration/fork-proxy-connection-unique.int.c
 
 test_integration_fork_tcti_create_after_int_LDADD = $(TEST_INT_LIBS)
 test_integration_fork_tcti_create_after_int_SOURCES = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,7 @@ TESTS_INTEGRATION = \
     test/integration/auth-session-start-flush.int \
     test/integration/auth-session-start-save.int \
     test/integration/auth-session-start-save-load.int \
+    test/integration/fork-tcti-parent-before-child-after.int \
     test/integration/max-transient-upperbound.int \
     test/integration/get-capability-handles-transient.int \
     test/integration/manage-transient-keys.int \
@@ -71,6 +72,7 @@ TESTS_INTEGRATION_NOHW = test/integration/tcti-connect-multiple.int
 TESTS =
 noinst_LTLIBRARIES =
 XFAIL_TESTS = \
+    test/integration/fork-tcti-parent-before-child-after.int \
     test/integration/start-auth-session.int
 TEST_EXTENSIONS = .int
 AM_TESTS_ENVIRONMENT = \
@@ -459,6 +461,10 @@ test_integration_auth_session_start_save_int_SOURCES = test/integration/main.c \
 test_integration_auth_session_start_save_load_int_LDADD = $(TEST_INT_LIBS)
 test_integration_auth_session_start_save_load_int_SOURCES = test/integration/main.c \
     test/integration/auth-session-start-save-load.int.c
+
+test_integration_fork_tcti_parent_before_child_after_int_LDADD = $(TEST_INT_LIBS)
+test_integration_fork_tcti_parent_before_child_after_int_SOURCES = \
+    test/integration/fork-tcti-parent-before-child-after.int.c
 
 test_integration_max_transient_upperbound_int_LDADD = $(TEST_INT_LIBS)
 test_integration_max_transient_upperbound_int_SOURCES = test/integration/main.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,7 @@ TESTS_INTEGRATION = \
     test/integration/auth-session-start-flush.int \
     test/integration/auth-session-start-save.int \
     test/integration/auth-session-start-save-load.int \
+    test/integration/fork-tcti-create-after.int \
     test/integration/fork-tcti-parent-before-child-after.int \
     test/integration/max-transient-upperbound.int \
     test/integration/get-capability-handles-transient.int \
@@ -461,6 +462,10 @@ test_integration_auth_session_start_save_int_SOURCES = test/integration/main.c \
 test_integration_auth_session_start_save_load_int_LDADD = $(TEST_INT_LIBS)
 test_integration_auth_session_start_save_load_int_SOURCES = test/integration/main.c \
     test/integration/auth-session-start-save-load.int.c
+
+test_integration_fork_tcti_create_after_int_LDADD = $(TEST_INT_LIBS)
+test_integration_fork_tcti_create_after_int_SOURCES = \
+    test/integration/fork-tcti-create-after.int.c
 
 test_integration_fork_tcti_parent_before_child_after_int_LDADD = $(TEST_INT_LIBS)
 test_integration_fork_tcti_parent_before_child_after_int_SOURCES = \

--- a/test/integration/fork-proxy-connection-unique.int.c
+++ b/test/integration/fork-proxy-connection-unique.int.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018, Intel Corporation
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#include <errno.h>
+#include <gio/gio.h>
+#include <glib.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+GDBusProxy*
+create_proxy_simple (void)
+{
+    GDBusProxy *proxy;
+
+    proxy = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
+                                           G_DBUS_PROXY_FLAGS_NONE,
+                                           NULL,
+                                           "org.freedesktop.DBus",
+                                           "/org/freedesktop/DBus",
+                                           "org.freedesktop.DBus.ListNames",
+                                           NULL,
+                                           &error);
+    g_assert_no_error (error);
+
+    return proxy;
+}
+
+GDBusProxy*
+create_proxy_via_addr_conn (void)
+{
+    GDBusConnection *connection;
+    GDBusProxy *proxy;
+    GError *error = NULL;
+    gboolean ret;
+    char *address;
+
+    address = g_dbus_address_get_for_bus_sync (G_BUS_TYPE_SESSION, NULL, &error);
+    g_assert_no_error (error);
+
+    g_debug ("%s: g_dbus_connection_new_for_address_sync: %s", __func__, address);
+    connection = g_dbus_connection_new_for_address_sync (
+        address,
+        G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT | G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION,
+        NULL,
+        NULL,
+        &error);
+    g_assert_no_error (error);
+
+    g_debug ("%s: g_initable_init", __func__);
+    ret = g_initable_init (G_INITABLE (connection), NULL, &error);
+    g_assert_no_error (error);
+    if (ret == FALSE)
+        g_error ("g_initable_init returned FALSE");
+
+    g_debug ("%s: g_dbus_proxy_new_sync", __func__);
+    proxy = g_dbus_proxy_new_sync (connection,
+                                   G_DBUS_PROXY_FLAGS_NONE,
+                                   NULL,
+                                   "org.freedesktop.DBus",
+                                   "/org/freedesktop/DBus",
+                                   "org.freedesktop.DBus.ListNames",
+                                   NULL,
+                                   &error);
+    g_assert_no_error (error);
+
+    g_clear_object (&connection);
+    g_free (address);
+
+    return proxy;
+}
+/*
+ */
+int
+main (void)
+{
+    GDBusProxy *proxy;
+    pid_t pid;
+    int status;
+
+    proxy = create_proxy_via_addr_conn ();
+    pid = fork ();
+    /* crate proxy object child after fork */
+    if (pid == 0) {
+        g_debug ("%s: pid %d -> child", __func__, pid);
+        proxy = create_proxy_via_addr_conn ();
+    } else {
+        /* parent waitpid on child, check exit & signal status */
+        g_debug ("%s: pid %d -> parent", __func__, pid);
+        if (waitpid (pid, &status, 0) == -1) {
+            perror ("waitpid");
+            g_error ("%s:%d: waitpid failed: ", __func__, pid);
+        } else if (WEXITSTATUS (status)) {
+            g_error("%s:%d: child exit status %d", __func__, pid, status);
+        } else if (WIFSIGNALED (status)) {
+            g_error("%s:%d: child was killed by signal %d", __func__, pid, status);
+        }
+    }
+
+    g_debug ("%s:%d Test succeeded.", __func__, pid);
+    return 0;
+}

--- a/test/integration/fork-proxy-new-for-bus.int.c
+++ b/test/integration/fork-proxy-new-for-bus.int.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018, Intel Corporation
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#include <errno.h>
+#include <gio/gio.h>
+#include <glib.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/*
+ */
+int
+main (void)
+{
+    GDBusProxy *proxy [2];
+    GError *error = NULL;
+    pid_t pid;
+    int status;
+
+    proxy [0] = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
+                                               G_DBUS_PROXY_FLAGS_NONE,
+                                               NULL,
+                                               "org.freedesktop.DBus",
+                                               "/org/freedesktop/DBus",
+                                               "org.freedesktop.DBus.ListNames",
+                                               NULL,
+                                               &error);
+    g_assert_no_error (error);
+    /* return 0; */
+    pid = fork ();
+    /* crate proxy object child after fork */
+    if (pid == 0) {
+        g_debug ("%s: pid %d -> child", __func__, pid);
+        proxy [1] = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
+                                               G_DBUS_PROXY_FLAGS_NONE,
+                                               NULL,
+                                               "org.freedesktop.DBus",
+                                               "/org/freedesktop/DBus",
+                                               "org.freedesktop.DBus.ListNames",
+                                               NULL,
+                                               &error);
+        g_assert_no_error (error);
+    } else {
+        /* parent waitpid on child, check exit & signal status */
+        g_debug ("%s: pid %d -> parent", __func__, pid);
+        if (waitpid (pid, &status, 0) == -1) {
+            perror ("waitpid");
+            g_error ("%s:%d: waitpid failed: ", __func__, pid);
+        } else if (WEXITSTATUS (status)) {
+            g_error("%s:%d: child exit status %d", __func__, pid, status);
+        } else if (WIFSIGNALED (status)) {
+            g_error("%s:%d: child was killed by signal %d", __func__, pid, status);
+        }
+    }
+
+    g_debug ("%s:%d Test succeeded.", __func__, pid);
+    return 0;
+}

--- a/test/integration/fork-proxy.int.c
+++ b/test/integration/fork-proxy.int.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018, Intel Corporation
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#include <errno.h>
+#include <gio/gio.h>
+#include <glib.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/*
+ */
+int
+main (void)
+{
+    GDBusConnection *connection [2];
+    GDBusProxy *proxy [2];
+    GError *error = NULL;
+    pid_t pid;
+    int status;
+
+    connection [0] = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &error);
+    g_assert_no_error (error);
+    proxy [0] = g_dbus_proxy_new_sync (connection [0],
+                                       G_DBUS_PROXY_FLAGS_NONE,
+                                       NULL,
+                                       "org.freedesktop.DBus",
+                                       "/org/freedesktop/DBus",
+                                       "org.freedesktop.DBus.ListNames",
+                                       NULL,
+                                       &error);
+    g_assert_no_error (error);
+    return 0;
+    pid = fork ();
+    /* crate proxy object child after fork */
+    if (pid == 0) {
+        g_debug ("%s: pid %d -> child", __func__, pid);
+        connection [1] = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &error);
+        g_assert_no_error (error);
+        proxy [1] = g_dbus_proxy_new_sync (connection [1],
+                                           G_DBUS_PROXY_FLAGS_NONE,
+                                           NULL,
+                                           "org.freedesktop.DBus",
+                                           "/org/freedesktop/DBus",
+                                           "org.freedesktop.DBus.ListNames",
+                                           NULL,
+                                           &error);
+        g_assert_no_error (error);
+    } else {
+        /* parent waitpid on child, check exit & signal status */
+        g_debug ("%s: pid %d -> parent", __func__, pid);
+        if (waitpid (pid, &status, 0) == -1) {
+            perror ("waitpid");
+            g_error ("%s:%d: waitpid failed: ", __func__, pid);
+        } else if (WEXITSTATUS (status)) {
+            g_error("%s:%d: child exit status %d", __func__, pid, status);
+        } else if (WIFSIGNALED (status)) {
+            g_error("%s:%d: child was killed by signal %d", __func__, pid, status);
+        }
+    }
+
+    g_debug ("%s:%d Test succeeded.", __func__, pid);
+    return 0;
+}

--- a/test/integration/fork-tcti-create-after.int.c
+++ b/test/integration/fork-tcti-create-after.int.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018, Intel Corporation
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#include <errno.h>
+#include <glib.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <tss2/tss2_tcti.h>
+
+#include "test-options.h"
+#include "context-util.h"
+/*
+ * This code tests the ability to instantiate instances of the TCTI across
+ * a process fork. This test specifically creates a TCTI (connection to
+ * tabrmd), then forks and the child creates a TCTI while the parent process
+ * waits. The parent must check the exit status as well as whether or not it
+ * was killed by a signal (happens on g_error).
+ */
+int
+main (void)
+{
+    TSS2_TCTI_CONTEXT *tcti_ctx;
+    test_opts_t opts = TEST_OPTS_DEFAULT_INIT;
+    pid_t pid;
+    int status = 0;
+
+    get_test_opts_from_env (&opts);
+    if (sanity_check_test_opts (&opts) != 0) {
+        return 1;
+    }
+
+    pid = fork ();
+    /* crate tcti in both parent and child after fork */
+    if (pid == 0) {
+        g_debug ("%s: pid %d -> child", __func__, pid);
+    }
+    tcti_ctx = tcti_init_from_opts (&opts);
+    if (tcti_ctx == NULL) {
+        g_error ("%s:%d: Failed to create tcti context from opts", __func__, pid);
+    }
+    if (pid != 0) {
+        /* parent waitpid on child, check exit & signal status */
+        g_debug ("%s: pid %d -> parent", __func__, pid);
+        if (waitpid (pid, &status, 0) == -1) {
+            perror ("waitpid");
+            g_error ("%s:%d: waitpid failed: ", __func__, pid);
+        } else if (WEXITSTATUS (status)) {
+            g_error("%s:%d: child exit status %d", __func__, pid, status);
+        } else if (WIFSIGNALED (status)) {
+            g_error("%s:%d: child was killed by signal %d", __func__, pid, status);
+        }
+    }
+
+    g_debug ("%s:%d Test succeeded.", __func__, pid);
+    return 0;
+}

--- a/test/integration/fork-tcti-parent-before-child-after.int.c
+++ b/test/integration/fork-tcti-parent-before-child-after.int.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018, Intel Corporation
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#include <errno.h>
+#include <glib.h>
+#include <inttypes.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <tss2/tss2_tcti.h>
+
+#include "test-options.h"
+#include "context-util.h"
+/*
+ * This code tests the ability to instantiate instances of the TCTI across
+ * a process fork. This test specifically creates a TCTI (connection to
+ * tabrmd), then forks and the child creates a TCTI while the parent process
+ * waits. The parent must check the exit status as well as whether or not it
+ * was killed by a signal (happens on g_error).
+ */
+int
+main (void)
+{
+    TSS2_TCTI_CONTEXT *tcti_ctx [2];
+    test_opts_t opts = TEST_OPTS_DEFAULT_INIT;
+    pid_t pid;
+    int status = 0;
+
+    /* create TCTI in parent */
+    get_test_opts_from_env (&opts);
+    if (sanity_check_test_opts (&opts) != 0) {
+        return 1;
+    }
+    tcti_ctx [0] = tcti_init_from_opts (&opts);
+    if (tcti_ctx [0] == NULL) {
+        g_error ("%s: Failed to create tcti context from opts", __func__);
+    }
+    pid = fork ();
+    if (pid == 0) {
+        /* create TCTI in child */
+        g_debug ("%s: pid %d -> child", __func__, pid);
+        tcti_ctx [1] = tcti_init_from_opts (&opts);
+        if (tcti_ctx [1] == NULL) {
+            g_error ("%s:%d: Failed to create tcti context from opts", __func__, pid);
+        }
+    } else {
+        /* parent waitpid on child, check exit & signal status */
+        g_debug ("%s: pid %d -> parent", __func__, pid);
+        if (waitpid (pid, &status, 0) == -1) {
+            perror ("waitpid");
+            g_error ("%s:%d: waitpid failed: ", __func__, pid);
+        } else if (WEXITSTATUS (status)) {
+            g_error("%s:%d: child exit status %d", __func__, pid, status);
+        } else if (WIFSIGNALED (status)) {
+            g_error("%s:%d: child was killed by signal %d", __func__, pid, status);
+        }
+    }
+
+    g_debug ("%s:%d Test succeeded.", __func__, pid);
+    return 0;
+}


### PR DESCRIPTION
This PR is two tests that cover scenarios where the test creates TCTI connection initialization before and after the 'fork' systemcall. This is part of work toward a resulution for #541 