### PR TITLE
Simplify autotools machinery

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -295,7 +295,7 @@ endef # man_tcti_prefix
 
 %-generated.c %-generated.h : src/tabrmd.xml
 	$(AM_V_GEN)$(call make_parent_dir,$@) && \
-	$(GDBUS_CODEGEN) --interface-prefix=com.intel.tss2. \
+	gdbus-codegen --interface-prefix=com.intel.tss2. \
 	    --generate-c-code=src/tabrmd-generated $^
 
 %.preset : %.preset.in

--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ PKG_CHECK_MODULES([GLIB], [glib-2.0])
 PKG_CHECK_MODULES([GOBJECT], [gobject-2.0])
 PKG_CHECK_MODULES([TSS2_SYS],[tss2-sys >= 2.0.0])
 AC_ARG_VAR([GDBUS_CODEGEN],[The gdbus-codegen executable.])
-AC_PATH_PROG([GDBUS_CODEGEN], [gdbus-codegen])
+AC_CHECK_PROG([GDBUS_CODEGEN], [gdbus-codegen], [gdbus-codegen])
 if test -z "$GDBUS_CODEGEN"; then
     AC_MSG_ERROR([*** gdbus-codegen is required to build tpm2-abrmd])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -34,15 +34,10 @@ AC_SEARCH_LIBS([dlopen], [dl dld], [], [
   AC_MSG_ERROR([unable to find the dlopen() function])
 ])
 PKG_CHECK_MODULES([DBUS], [dbus-1])
-PKG_CHECK_MODULES([GIO], [gio-unix-2.0])
+PKG_CHECK_MODULES([GIO], [gio-2.0 gio-unix-2.0])
 PKG_CHECK_MODULES([GLIB], [glib-2.0])
 PKG_CHECK_MODULES([GOBJECT], [gobject-2.0])
 PKG_CHECK_MODULES([TSS2_SYS],[tss2-sys >= 2.0.0])
-AC_ARG_VAR([GDBUS_CODEGEN],[The gdbus-codegen executable.])
-AC_CHECK_PROG([GDBUS_CODEGEN], [gdbus-codegen], [gdbus-codegen])
-if test -z "$GDBUS_CODEGEN"; then
-    AC_MSG_ERROR([*** gdbus-codegen is required to build tpm2-abrmd])
-fi
 
 AX_CODE_COVERAGE
 # disable helgrind and drd, they hate GAsyncQueue


### PR DESCRIPTION
We don't need to explicitly check for the existence of gdbus-codegen, nor store its path. It should be safe to assume that the binary is available on `PATH` for any system with the gio pkg-config files available.