### PR TITLE
build: Do not include llvm profiling file in dist target.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -153,7 +153,7 @@ CLEANFILES = \
     $(systemdsystemunit_DATA) \
     test/integration/*.log \
     _tabrmd.log
-DISTCLEANFILES = core
+DISTCLEANFILES = core default.profraw
 
 BUILT_SOURCES = src/tabrmd-generated.h src/tabrmd-generated.c
 


### PR DESCRIPTION
Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>