### PR TITLE
travis-ci: Build tpm2-tss using gcrypt.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
   - git clone -b master --single-branch https://github.com/01org/tpm2-tss.git
   - pushd tpm2-tss
   - ./bootstrap
-  - ./configure --prefix=${PREFIX}
+  - ./configure --prefix=${PREFIX} --with-crypto=gcrypt
   - make -j$(nproc) install
   - popd # tpm2-tss
   - sed -i -e "s&\(\/usr\/lib\/lib.*\.la\)&${DESTDIR}\1&" ${DESTDIR}${PREFIX}/lib/*.la


### PR DESCRIPTION
Upstream the tpm2-tss is now defaulting to use openssl as its crypto
library. Supporting this will require a few changes to the ci build.
Best short-term fix is to keep using grcypt until ci is update.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>