### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       - dbus
       - dbus-x11
       - doxygen
+      - gnulib
       - cmake
       - lcov
       - libglib2.0-dev
@@ -62,7 +63,7 @@ install:
   - popd # cmocka
   - git clone -b master --single-branch https://github.com/01org/tpm2-tss.git
   - pushd tpm2-tss
-  - ./bootstrap
+  - ./bootstrap -I /usr/share/gnulib/m4
   - ./configure --prefix=${PREFIX} --disable-doxygen-doc --disable-tcti-device --disable-esapi
   - make -j$(nproc) install
   - popd # tpm2-tss

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
       - autoconf-archive
       - dbus
       - dbus-x11
-      - doxygen
       - gnulib
       - cmake
       - lcov


### PR DESCRIPTION
Since https://github.com/tpm2-software/tpm2-tss/pull/1199 was merged upstream, the Gnulib include directory [needs to be specified during bootstrap of tpm2-tss](https://github.com/tpm2-software/tpm2-tss/blob/master/INSTALL.md#bootstrapping-the-build).

Also remove the doxygen package, which is not necessary any more since https://github.com/tpm2-software/tpm2-tss/pull/1209 was merged.