### PR TITLE
ci: Provide path to gnulib m4 to tpm2-tss bootstrap script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
       - dbus-x11
       - doxygen
       - cmake
+      - gnulib
       - lcov
       - libglib2.0-dev
       - libdbus-1-dev
@@ -62,7 +63,7 @@ install:
   - popd # cmocka
   - git clone -b master --single-branch https://github.com/01org/tpm2-tss.git
   - pushd tpm2-tss
-  - ./bootstrap
+  - ./bootstrap --include=/usr/share/gnulib/m4
   - ./configure --prefix=${PREFIX} --disable-doxygen-doc --disable-tcti-device --disable-esapi
   - make -j$(nproc) install
   - popd # tpm2-tss


### PR DESCRIPTION
Upstream tpm2-tss build no longer ships the ld script. Instead it relies
on the one packaged with gnulib. This currently requires the path be
passed to the bootstrap script directly.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>