### PR TITLE
build: Stop including libtest in LIBADD for tcti lib.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -256,7 +256,7 @@ test_integration_libtest_la_SOURCES = \
     test/mock-io-stream.h
 
 src_libtss2_tcti_tabrmd_la_LIBADD   = $(DBUS_LIBS) $(GIO_LIBS) $(GLIB_LIBS) \
-    $(PTHREAD_LIBS) $(noinst_LTLIBRARIES) $(TSS2_SYS_LIBS)
+    $(PTHREAD_LIBS) $(libutil) $(TSS2_SYS_LIBS)
 src_libtss2_tcti_tabrmd_la_LDFLAGS = -fPIC -Wl,--no-undefined -Wl,--version-script=$(srcdir)/src/tcti-tabrmd.map
 src_libtss2_tcti_tabrmd_la_SOURCES = src/tcti-tabrmd.c src/tcti-tabrmd-priv.h $(srcdir)/src/tcti-tabrmd.map
 


### PR DESCRIPTION
The automake noinst_LTLIBRARIES variable was being used to include
the utility library for linking with the TCTI library. When the
integration tests are enabled they must be  added to this variable as
well which causes it to be linked into the TCTI library unnecessarily.
This bloats the shared object. This patch removes the problematic use of
noinst_LTLIBRARIES using libutil directly instead.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>