### PR TITLE
handle TPM2_RC_CONTEXT_GAP

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,6 @@ TESTS_INTEGRATION_NOHW = test/integration/tcti-connect-multiple.int
 TESTS =
 noinst_LTLIBRARIES =
 XFAIL_TESTS = \
-    test/integration/session-gap.int \
     test/integration/start-auth-session.int
 TEST_EXTENSIONS = .int
 AM_TESTS_ENVIRONMENT = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -207,6 +207,8 @@ src_libutil_la_SOURCES = \
     src/message-queue.h \
     src/random.c \
     src/random.h \
+    src/resource-manager-session.c \
+    src/resource-manager-session.h \
     src/resource-manager.c \
     src/resource-manager.h \
     src/response-sink.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,7 @@ TESTS_INTEGRATION = \
     test/integration/max-transient-upperbound.int \
     test/integration/get-capability-handles-transient.int \
     test/integration/manage-transient-keys.int \
+    test/integration/session-gap.int \
     test/integration/session-load-from-closed-connection.int \
     test/integration/session-load-from-closed-connections-lru.int \
     test/integration/session-load-from-open-connection.int \
@@ -70,6 +71,7 @@ TESTS_INTEGRATION_NOHW = test/integration/tcti-connect-multiple.int
 TESTS =
 noinst_LTLIBRARIES =
 XFAIL_TESTS = \
+    test/integration/session-gap.int \
     test/integration/start-auth-session.int
 TEST_EXTENSIONS = .int
 AM_TESTS_ENVIRONMENT = \
@@ -454,6 +456,10 @@ test_integration_max_transient_upperbound_int_SOURCES = test/integration/main.c 
 test_integration_get_capability_handles_transient_int_LDADD = $(TEST_INT_LIBS)
 test_integration_get_capability_handles_transient_int_SOURCES = \
     test/integration/main.c test/integration/get-capability-handles-transient.int.c
+
+test_integration_session_gap_int_LDADD = $(TEST_INT_LIBS)
+test_integration_session_gap_int_SOURCES = test/integration/main.c \
+    test/integration/session-gap.int.c
 
 test_integration_session_load_from_open_connection_int_LDADD = $(TEST_INT_LIBS)
 test_integration_session_load_from_open_connection_int_SOURCES = \

--- a/src/resource-manager-session.c
+++ b/src/resource-manager-session.c
@@ -1,0 +1,137 @@
+/* SPDX-License-Identifier: BSD-2 */
+#include <glib.h>
+#include <inttypes.h>
+
+#include "access-broker.h"
+#include "resource-manager.h"
+#include "resource-manager-session.h"
+#include "session-list.h"
+#include "session-entry.h"
+#include "tabrmd.h"
+#include "tpm2-command.h"
+#include "tpm2-header.h"
+#include "tpm2-response.h"
+#include "util.h"
+
+/*
+ * Load the TPMS_CONTEXT associated with the provided SessionEntry*.
+ * This function will always return a Tpm2Response object (never NULL)
+ * though the response object may indicate a failure in the response code.
+ */
+Tpm2Response*
+load_session (ResourceManager *resmgr,
+              SessionEntry *entry)
+{
+    Tpm2Command *cmd = NULL;
+    Tpm2Response *resp = NULL;
+    size_buf_t *size_buf = NULL;
+    TSS2_RC rc = TSS2_RC_SUCCESS;
+
+    g_debug ("%s: SessionEntry 0x%" PRIxPTR, __func__, (uintptr_t)entry);
+    size_buf = session_entry_get_context (entry);
+    cmd = tpm2_command_new_context_load (size_buf->buf, size_buf->size);
+    if (cmd == NULL) {
+        g_critical ("%s: failed to allcoate ContextLoad Tpm2Command",
+                    __func__);
+        resp = tpm2_response_new_rc (NULL, TSS2_RESMGR_RC_GENERAL_FAILURE);
+        goto out;
+    }
+    resp = access_broker_send_command (resmgr->access_broker, cmd, &rc);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_critical ("%s: TCTI failed while loading session context from "
+                   "SessionEntry 0x%" PRIxPTR ", got RC 0x%" PRIx32,
+                   __func__, (uintptr_t)entry, rc);
+        resp = tpm2_response_new_rc (NULL, rc);
+        goto out;
+    }
+    rc = tpm2_response_get_code (resp);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_warning ("%s: failed to ContextLoad SessionEntry 0x%" PRIxPTR ", got "
+                   "RC 0x%" PRIx32, __func__, (uintptr_t)entry, rc);
+        goto out;
+    }
+    session_entry_set_state (entry, SESSION_ENTRY_LOADED);
+out:
+    g_clear_object (&cmd);
+    return resp;
+}
+/*
+ * This function flushes the context associated with the provided SessionEntry
+ * from the TPM. Once a session is flushed it cannot be re-loaded and so we
+ * remove the SessionEntry from the session_list as well.
+ */
+gboolean
+flush_session (ResourceManager *resmgr,
+               SessionEntry *entry)
+{
+    g_assert_nonnull (resmgr);
+    g_assert_nonnull (entry);
+
+    TPM2_HANDLE handle = session_entry_get_handle (entry);
+    TSS2_RC rc;
+
+    g_debug ("%s: flushing stale SessionEntry: 0x%" PRIxPTR " with "
+             "handle: 0x%08" PRIx32,
+             __func__, (uintptr_t)entry, handle);
+    rc = access_broker_context_flush (resmgr->access_broker, handle);
+    session_list_remove (resmgr->session_list, entry);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_warning ("%s: failed to flush session context with "
+                   "handle 0x%" PRIx32 ": 0x%" PRIx32,
+                   __func__, handle, rc);
+        return FALSE;
+    }
+    return TRUE;
+}
+/*
+ * Saves context of the provided SessionEntry. If successful the
+ * SessionEntry state will be udpated and the context blob updated. The
+ * function will always return a Tpm2Response. If there was any error
+ * encounterd it will be reflected in the Tpm2Response object RC.
+ */
+Tpm2Response*
+save_session (ResourceManager *resmgr,
+              SessionEntry *entry)
+{
+    Tpm2Command *cmd = NULL;
+    Tpm2Response *resp = NULL;
+    TSS2_RC rc = TSS2_RC_SUCCESS;
+
+    g_assert_nonnull (resmgr);
+    g_assert_nonnull (entry);
+    g_debug ("%s: SessionEntry: 0x%" PRIxPTR, __func__, (uintptr_t)entry);
+    if (session_entry_get_state (entry) != SESSION_ENTRY_LOADED) {
+        g_critical ("%s: SessionEntry 0x%" PRIxPTR " already loaded",
+                    __func__, (uintptr_t)entry);
+        resp = tpm2_response_new_rc (NULL, TSS2_RESMGR_RC_GENERAL_FAILURE);
+        goto out;
+    }
+    cmd = tpm2_command_new_context_save (session_entry_get_handle (entry));
+    if (cmd == NULL) {
+        g_critical ("%s: failed to allocate ContextSave Tpm2Command",
+                    __func__);
+        resp = tpm2_response_new_rc (NULL, TSS2_RESMGR_RC_GENERAL_FAILURE);
+        goto out;
+    }
+    resp = access_broker_send_command (resmgr->access_broker, cmd, &rc);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_critical ("%s: TCTI failed while saving session context from "
+                   "SessionEntry 0x%" PRIxPTR ", got RC 0x%" PRIx32,
+                   __func__, (uintptr_t)entry, rc);
+        resp = tpm2_response_new_rc (NULL, rc);
+        goto out;
+    }
+    rc = tpm2_response_get_code (resp);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_info ("%s: failed to ContextSave SessionEntry 0x%" PRIxPTR ", got "
+                "RC 0x%" PRIx32, __func__, (uintptr_t)entry, rc);
+        goto out;
+    }
+    session_entry_set_context (entry,
+                               &tpm2_response_get_buffer (resp)[TPM_HEADER_SIZE],
+                               tpm2_response_get_size (resp) - TPM_HEADER_SIZE);
+    session_entry_set_state (entry, SESSION_ENTRY_SAVED_RM);
+out:
+    g_clear_object (&cmd);
+    return resp;
+}

--- a/src/resource-manager-session.h
+++ b/src/resource-manager-session.h
@@ -19,4 +19,7 @@ flush_session (ResourceManager *resmgr,
 Tpm2Response*
 save_session (ResourceManager *resmgr,
               SessionEntry *entry);
+gboolean
+regap_session (ResourceManager *resmgr,
+               SessionEntry *entry);
 #endif

--- a/src/resource-manager-session.h
+++ b/src/resource-manager-session.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-2 */
+#ifndef RESOURCE_MANAGER_SESSION_H
+#define RESOURCE_MANAGER_SESSION_H
+
+#include <glib.h>
+#include <inttypes.h>
+
+#include <tss2/tss2_tpm2_types.h>
+
+#include "resource-manager.h"
+#include "session-entry.h"
+
+Tpm2Response*
+load_session (ResourceManager *resmgr,
+              SessionEntry *entry);
+gboolean
+flush_session (ResourceManager *resmgr,
+               SessionEntry *entry);
+Tpm2Response*
+save_session (ResourceManager *resmgr,
+              SessionEntry *entry);
+#endif

--- a/src/session-list.c
+++ b/src/session-list.c
@@ -555,7 +555,6 @@ session_list_prune_abandoned (SessionList *list,
         return TRUE;
     }
     g_object_ref (entry);
-    session_list_remove (list, entry);
     ret = func (entry, data);
     g_clear_object (&entry);
     return ret;

--- a/test/integration/common.c
+++ b/test/integration/common.c
@@ -34,6 +34,43 @@
 #include "tss2-tcti-tabrmd.h"
 #include "tpm2-struct-init.h"
 
+TSS2_RC
+get_context_gap_max (TSS2_SYS_CONTEXT *sys_context,
+                     UINT32 *value)
+{
+    TPMI_YES_NO more_data = TPM2_NO;
+    TPMS_CAPABILITY_DATA capability_data;
+    TSS2_RC rc;
+
+    g_debug ("%s: GetCapability", __func__);
+    rc = Tss2_Sys_GetCapability (sys_context,
+                                 NULL,
+                                 TPM2_CAP_TPM_PROPERTIES,
+                                 TPM2_PT_CONTEXT_GAP_MAX,
+                                 1,
+                                 &more_data,
+                                 &capability_data,
+                                 NULL);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_error ("%s: GetCapability failed with RC: 0x%" PRIx32, __func__, rc);
+    }
+    if (capability_data.capability != TPM2_CAP_TPM_PROPERTIES) {
+        g_error ("%s: capability returned is unexpected value: 0x%" PRIx32,
+                 __func__, capability_data.capability);
+    }
+    if (capability_data.data.tpmProperties.count != 1) {
+        g_error ("%s: capability returned is unexpected count: 0x%" PRIx32,
+                 __func__, capability_data.data.tpmProperties.count);
+    }
+    if (capability_data.data.tpmProperties.tpmProperty[0].property != TPM2_PT_CONTEXT_GAP_MAX) {
+        g_error ("%s: capability returned wrong property: 0x%" PRIx32,
+                 __func__, capability_data.data.tpmProperties.tpmProperty[0].property);
+    }
+    g_debug ("%s: TPM2_PT_CONTEXT_GAP_MAX value: 0x%" PRIx32, __func__,
+             capability_data.data.tpmProperties.tpmProperty[0].value);
+    *value = capability_data.data.tpmProperties.tpmProperty[0].value;
+    return rc;
+}
 /*
  */
 TSS2_RC

--- a/test/integration/common.h
+++ b/test/integration/common.h
@@ -55,6 +55,11 @@
 #define PRIxHANDLE "08" PRIx32
 
 TSS2_RC
+get_context_gap_max (
+    TSS2_SYS_CONTEXT *sys_context,
+    UINT32 *value);
+
+TSS2_RC
 create_primary (
     TSS2_SYS_CONTEXT *sapi_context,
     TPM2_HANDLE       *handle

--- a/test/integration/session-gap.int.c
+++ b/test/integration/session-gap.int.c
@@ -1,0 +1,101 @@
+/* SPDX-License-Identifier: BSD-2 */
+#include <inttypes.h>
+#include <glib.h>
+#include <string.h>
+
+#include <tss2/tss2_sys.h>
+
+#include "common.h"
+#include "test.h"
+#define PRIxHANDLE "08" PRIx32
+#define PRIxRC PRIx32
+
+#define FIRST_CONTEXT_SEQUENCE 0x4
+
+/*
+ * This test exercises the resource manager's handling of the session gap
+ * mechanism. Currently the RM does not 'virtualize' the GetCapability
+ * TPM2_PT_CONTEXT_GAP_MAX property. This allows us to use the value
+ * returned by the simulator to detect the proper function of the
+ * ResourceManager. We do this by detecting a rollover in the context
+ * sequence number.
+ *
+ * Under normal circumstances (when run against the simulator w/o the RM)
+ * we will cause a TPM_RC_CONTEXT_GAP error before the sequence number of
+ * the last saved session exceeds that of the first. If we do not, then we
+ * consider the test a success.
+ *
+ */
+int
+test_invoke (TSS2_SYS_CONTEXT *sapi_context)
+{
+    TSS2_RC rc;
+    TPMI_SH_AUTH_SESSION session_handle = 0, session_handle_trans = 0;
+    TPMS_CONTEXT context = { 0 }, context_tmp = { 0 };
+    UINT32 gap_max = 0;
+    UINT64 initial_sequence = 0, last_sequence = 0;
+
+    rc = get_context_gap_max (sapi_context, &gap_max);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_error ("%s: get_context_gap_max failed with RC: 0x%" PRIx32,
+                 __func__, rc);
+    }
+    g_info ("%s: GAP_MAX is 0x%" PRIx32, __func__, gap_max);
+    g_info ("%s: Starting unbound, unsalted auth session", __func__);
+    rc = start_auth_session (sapi_context, &session_handle);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_error ("Tss2_Sys_StartAuthSession failed: 0x%" PRIxRC, rc);
+    }
+    g_info ("%s: StartAuthSession for TPM_SE_POLICY success! Session handle: "
+            "0x%" PRIxHANDLE, __func__, session_handle);
+    rc = Tss2_Sys_ContextSave (sapi_context, session_handle, &context);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_error ("Failed to save context for initial session: 0x%" PRIxRC, rc);
+    }
+    g_info ("%s: Saved context for session with handle: 0x%" PRIxHANDLE " and "
+            "sequence: 0x%" PRIx64, __func__, session_handle, context.sequence);
+    initial_sequence = last_sequence = context.sequence;
+    g_debug ("%s: initial_sequence: 0x%" PRIx64 ", last_sequence: 0x%"
+             PRIx64 ", gap_max: 0x%" PRIx32, __func__, initial_sequence,
+             last_sequence, gap_max);
+    for (last_sequence = initial_sequence;
+         last_sequence - initial_sequence < gap_max;
+         last_sequence = context_tmp.sequence)
+    {
+        /*
+         * NOTE: To trigger the GAP RC it's not strictly necessary for us
+         * to save the session context in this loop as the RM will save it
+         * as part of its normal operation. To make this test work against
+         * the simulator however we must do the save operation here even
+         * though it's redundant when running against the RM.
+         */
+        g_debug ("%s: last_sequence: %" PRIx64, __func__, last_sequence);
+        g_debug ("%s: initial_sequence: %" PRIx64, __func__, initial_sequence);
+        rc = start_auth_session (sapi_context, &session_handle_trans);
+        if (rc != TSS2_RC_SUCCESS) {
+            g_error ("Tss2_Sys_StartAuthSession failed: 0x%" PRIxRC, rc);
+        }
+        memset (&context_tmp, 0, sizeof (TPMS_CONTEXT));
+        g_info ("%s: StartAuthSession for TPM_SE_POLICY success! Session handle: "
+                "0x%" PRIxHANDLE, __func__, session_handle_trans);
+        rc = Tss2_Sys_ContextSave (sapi_context,
+                                   session_handle_trans,
+                                   &context_tmp);
+        if (rc != TSS2_RC_SUCCESS) {
+            g_error ("%s: Tss2_Sys_ContextSave failed for handle: 0x%" PRIxHANDLE
+                     " rc: 0x%" PRIxRC, __func__, session_handle_trans, rc);
+        }
+        g_debug ("%s: context_tmp.sequence: 0x%" PRIx64, __func__, context_tmp.sequence);
+        g_info ("%s: Saved context for session with handle: 0x%" PRIxHANDLE " and "
+                "sequence: 0x%" PRIx64, __func__, session_handle_trans, context_tmp.sequence);
+        rc = Tss2_Sys_FlushContext (sapi_context, session_handle_trans);
+        if (rc != TSS2_RC_SUCCESS) {
+            g_error ("%s: Tss2_Sys_FlushContext failed: 0x%" PRIxRC, __func__, rc);
+        }
+    }
+    g_info("%s: success: last_sequence - initial_sequence: 0x%"
+           PRIx64 ", gap_max - 1: 0x%" PRIx32, __func__,
+           last_sequence - initial_sequence, gap_max - 1);
+
+    return 0;
+}


### PR DESCRIPTION
This PR contains
- a test case to trigger and test for the proper handling of the context gap response code
- a bit of refactoring to cleanup the session context management functions in the ResourceManager object
- the logic necessary to handle the context gap response code on behalf of clients