### PR TITLE
test: Fix bad cast in ConnectionManager unit test.

### DIFF
--- a/test/connection-manager_unit.c
+++ b/test/connection-manager_unit.c
@@ -131,7 +131,7 @@ connection_manager_lookup_id_test (void **state)
     g_object_unref (iostream);
     ret = connection_manager_insert (manager, connection);
     assert_int_equal (ret, TSS2_RC_SUCCESS);
-    connection_lookup = connection_manager_lookup_id (manager, *(int*)connection_key_id (connection));
+    connection_lookup = connection_manager_lookup_id (manager, *(gint64*)connection_key_id (connection));
     assert_int_equal (connection, connection_lookup);
 }
 


### PR DESCRIPTION
The cast in this test got the type wrong and may be causing problems on
big endian architectures. This test is pretty ugly and should be
possible without the cast. A more permanent fix is future work.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>