### PR TITLE
build: disable unloading of libtss2-tcti-tabrmd.so

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -260,7 +260,7 @@ test_integration_libtest_la_SOURCES = \
 
 src_libtss2_tcti_tabrmd_la_LIBADD   = $(DBUS_LIBS) $(GIO_LIBS) $(GLIB_LIBS) \
     $(PTHREAD_LIBS) $(libutil) $(TSS2_SYS_LIBS)
-src_libtss2_tcti_tabrmd_la_LDFLAGS = -fPIC -Wl,--no-undefined -Wl,--version-script=$(srcdir)/src/tcti-tabrmd.map
+src_libtss2_tcti_tabrmd_la_LDFLAGS = -fPIC -Wl,--no-undefined -Wl,-z,nodelete -Wl,--version-script=$(srcdir)/src/tcti-tabrmd.map
 src_libtss2_tcti_tabrmd_la_SOURCES = src/tcti-tabrmd.c src/tcti-tabrmd-priv.h $(srcdir)/src/tcti-tabrmd.map
 
 src_tpm2_abrmd_LDADD   = $(DBUS_LIBS) $(GIO_LIBS) $(GLIB_LIBS) $(PTHREAD_LIBS) \


### PR DESCRIPTION
Happy new year! :tada: There is an issue when using the ESAPI from tpm2-tss together with tpm2-abrmd (see #545): When using [`Esys_Initialize`](https://github.com/tpm2-software/tpm2-tss/blob/35c121f6814beef3dbc369e60a2ca189eb381911/src/tss2-esys/esys_context.c#L20) with a `NULL` TCTI context in order to let tpm2-tss use its default TCTI,  the `libtss2-tcti-tabrmd.so` dynamic library is loaded with [`dlopen()`](https://github.com/tpm2-software/tpm2-tss/blob/54090544832a00fb78c65a91fc45e67c77fbd936/src/tss2-esys/esys_tcti_default.c#L135). When the ESAPI context is subsequently finalized with [`Esys_Finalize`](https://github.com/tpm2-software/tpm2-tss/blob/35c121f6814beef3dbc369e60a2ca189eb381911/src/tss2-esys/esys_context.c#L104), the dynamic library is then unloaded with [`dlclose()`](https://github.com/tpm2-software/tpm2-tss/blob/35c121f6814beef3dbc369e60a2ca189eb381911/src/tss2-esys/esys_context.c#L149). 

Due to the libdbus dependency of the `libtss2-tcti-tabrmd.so`, unloading it only works once: if you try to open it again with `dlopen()`, e.g. by using a second `Esys_Initialize`, it will segfault with a GLib error, see the example program in https://github.com/tpm2-software/tpm2-abrmd/issues/545#issuecomment-450571947. Note this only affects `Esys_Initialize` with a `NULL` TCTI context: if you provide a TCTI, you are responsible for cleaning up the context yourself. However if you don't provide the context, you don't have control over tpm2-tss unloading the dynamic library.

A simple solution to solve this issue is to disable unloading `libtss2-tcti-tabrmd.so` by marking it with the ` DF_1_NODELETE` flag (cf. the [dlopen man page](https://linux.die.net/man/3/dlopen) and the [ELF header specification](https://sourceware.org/git/?p=glibc.git;a=blob;f=elf/elf.h;h=47a514a389f0cdabc1c9e1b7d6817db7fd718727;hb=HEAD#l965)).

This might not be a very elegant solution, but it fulfils its purpose. I do not know if there is a way to completely unregister all D-Bus-related stuff so that dlclose() and a second dlopen() works without problems, but apparently linking with the `nodelete` flag [is also recommended by upstream](https://bugs.freedesktop.org/show_bug.cgi?id=54972#c68).