### PR TITLE
Mask object addresses in debug output.

### DIFF
--- a/src/access-broker.c
+++ b/src/access-broker.c
@@ -54,11 +54,11 @@ access_broker_set_property (GObject        *object,
 {
     AccessBroker *self = ACCESS_BROKER (object);
 
-    g_debug ("access_broker_set_property: 0x%" PRIxPTR, (uintptr_t)self);
+    g_debug ("access_broker_set_property: %p", objid (self));
     switch (property_id) {
     case PROP_SAPI_CTX:
         self->sapi_context = g_value_get_pointer (value);
-        g_debug ("  sapi_context: 0x%" PRIxPTR, (uintptr_t)self->sapi_context);
+        g_debug ("  sapi_context: %p", objid (self->sapi_context));
         break;
     case PROP_TCTI:
         if (self->tcti != NULL) {
@@ -67,7 +67,7 @@ access_broker_set_property (GObject        *object,
         }
         self->tcti = g_value_get_object (value);
         g_object_ref (self->tcti);
-        g_debug ("  tcti: 0x%" PRIxPTR, (uintptr_t)self->tcti);
+        g_debug ("  tcti: %p", objid (self->tcti));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -85,7 +85,7 @@ access_broker_get_property (GObject     *object,
 {
     AccessBroker *self = ACCESS_BROKER (object);
 
-    g_debug ("access_broker_get_property: 0x%" PRIxPTR, (uintptr_t)self);
+    g_debug ("access_broker_get_property: %p", objid (self));
     switch (property_id) {
     case PROP_SAPI_CTX:
         g_value_set_pointer (value, self->sapi_context);
@@ -174,7 +174,7 @@ sapi_context_init (Tcti *tcti)
     size_t size;
     TSS2_ABI_VERSION abi_version = SUPPORTED_ABI_VERSION;
 
-    g_debug ("sapi_context_init w/ Tcti: 0x%" PRIxPTR, (uintptr_t)tcti);
+    g_debug ("sapi_context_init w/ Tcti: %p", objid (tcti));
     tcti_context = tcti_peek_context (tcti);
     if (tcti_context == NULL)
         g_error ("NULL TCTI_CONTEXT");
@@ -393,9 +393,9 @@ access_broker_send_cmd (AccessBroker *broker,
                         tpm2_command_get_size (command),
                         tpm2_command_get_buffer (command));
     if (rc != TSS2_RC_SUCCESS)
-        g_warning ("AccessBroker 0x%" PRIxPTR " failed to transmit "
-                   "Tpm2Command 0x%" PRIxPTR ": 0x%" PRIx32,
-                   (uintptr_t)broker, (uintptr_t)command, rc);
+        g_warning ("AccessBroker %p" " failed to transmit "
+                   "Tpm2Command %p" ": 0x%" PRIx32,
+                   objid (broker), objid (command), rc);
     return rc;
 }
 /*
@@ -458,9 +458,8 @@ access_broker_send_command (AccessBroker  *broker,
     guint8         *buffer = NULL;
     size_t          buffer_size = 0;
 
-    g_debug ("access_broker_send_command: AccessBroker: 0x%" PRIxPTR
-             " Tpm2Command: 0x%" PRIxPTR, (uintptr_t)broker,
-             (uintptr_t)command);
+    g_debug ("%s: AccessBroker: %p Tpm2Command: %p", __func__,
+             objid (broker), objid (command));
     access_broker_lock (broker);
     *rc = access_broker_send_cmd (broker, command);
     if (*rc != TSS2_RC_SUCCESS)
@@ -475,9 +474,9 @@ access_broker_send_command (AccessBroker  *broker,
                                   buffer,
                                   buffer_size,
                                   tpm2_command_get_attributes (command));
-    g_debug ("access_broker_send_command: AccessBroker: 0x%" PRIxPTR
-             " Tpm2Response: 0x%" PRIxPTR " RC: 0x%" PRIx32, (uintptr_t)broker,
-             (uintptr_t)response, tpm2_response_get_code (response));
+    g_debug ("access_broker_send_command: AccessBroker: %p"
+             " Tpm2Response: %p RC: 0x%" PRIx32, objid (broker),
+             objid (response), tpm2_response_get_code (response));
     g_clear_object (&connection);
     return response;
 
@@ -523,7 +522,7 @@ access_broker_init_tpm (AccessBroker *broker)
 {
     TSS2_RC rc;
 
-    g_debug ("access_broker_init_tpm: 0x%" PRIxPTR, (uintptr_t)broker);
+    g_debug ("access_broker_init_tpm: %p", objid (broker));
     if (broker->initialized)
         return TSS2_RC_SUCCESS;
     pthread_mutex_init (&broker->sapi_mutex, NULL);
@@ -592,13 +591,12 @@ access_broker_context_load (AccessBroker *broker,
     rc = Tss2_Sys_ContextLoad (sapi_context, context, handle);
     access_broker_unlock (broker);
     if (rc == TSS2_RC_SUCCESS) {
-        g_debug ("Tss2_Sys_ContextLoad: successfully load context at 0x%"
-                 PRIxPTR " got handle 0x%" PRIx32, (uintptr_t)context,
-                 *handle);
+        g_debug ("Tss2_Sys_ContextLoad: successfully load context at %p"
+                 " got handle 0x%" PRIx32, objid (context), *handle);
     } else {
         g_warning ("Tss2_Sys_ContextLoad: failed to load context for "
-                   "context at: 0x%" PRIxPTR ", TSS2_RC: 0x%" PRIx32,
-                   (uintptr_t)context, rc);
+                   "context at: %p" ", TSS2_RC: 0x%" PRIx32,
+                   objid (context), rc);
     }
 
     return rc;
@@ -696,8 +694,8 @@ access_broker_flush_all_unlocked (AccessBroker     *broker,
     TPM2_HANDLE handle;
     size_t i;
 
-    g_debug ("%s: AccessBroker: 0x%" PRIxPTR ", first: 0x%08" PRIx32 ", last: "
-             "0x%08" PRIx32, __func__, (uintptr_t)broker, first, last);
+    g_debug ("%s: AccessBroker: %p" ", first: 0x%08" PRIx32 ", last: "
+             "0x%08" PRIx32, __func__, objid (broker), first, last);
     rc = Tss2_Sys_GetCapability (sapi_context,
                                  NULL,
                                  TPM2_CAP_HANDLES,
@@ -727,7 +725,7 @@ access_broker_flush_all_context (AccessBroker *broker)
 {
     TSS2_SYS_CONTEXT *sapi_context;
 
-    g_debug ("%s: AccessBroker: 0x%" PRIxPTR, __func__, (uintptr_t)broker);
+    g_debug ("%s: AccessBroker: %p", __func__, objid (broker));
     g_assert_nonnull (broker);
     sapi_context = access_broker_lock_sapi (broker);
     access_broker_flush_all_unlocked (broker,

--- a/src/command-attrs.c
+++ b/src/command-attrs.c
@@ -28,7 +28,7 @@ command_attrs_finalize (GObject *obj)
 {
     CommandAttrs *attrs = COMMAND_ATTRS (obj);
 
-    g_debug ("command_attrs_finalize: 0x%" PRIxPTR, (uintptr_t)attrs);
+    g_debug ("command_attrs_finalize: %p", objid (attrs));
     g_clear_pointer (&attrs->command_attrs, g_free);
     G_OBJECT_CLASS (command_attrs_parent_class)->finalize (obj);
 }

--- a/src/command-source.c
+++ b/src/command-source.c
@@ -39,8 +39,8 @@ command_source_add_sink (Source      *self,
     CommandSource *src = COMMAND_SOURCE (self);
     GValue value = G_VALUE_INIT;
 
-    g_debug ("command_source_add_sink: CommandSource: 0x%" PRIxPTR
-             " , Sink: 0x%" PRIxPTR, (uintptr_t)src, (uintptr_t)sink);
+    g_debug ("command_source_add_sink: CommandSource: %p, Sink: %p",
+             objid (src), objid (sink));
     g_value_init (&value, G_TYPE_OBJECT);
     g_value_set_object (&value, sink);
     g_object_set_property (G_OBJECT (src), "sink", &value);
@@ -109,11 +109,11 @@ command_source_set_property (GObject       *object,
 {
     CommandSource *self = COMMAND_SOURCE (object);
 
-    g_debug ("command_source_set_properties: 0x%" PRIxPTR, (uintptr_t)self);
+    g_debug ("command_source_set_properties: %p", objid (self));
     switch (property_id) {
     case PROP_COMMAND_ATTRS:
         self->command_attrs = COMMAND_ATTRS (g_value_dup_object (value));
-        g_debug ("  command_attrs: 0x%" PRIxPTR, (uintptr_t)self->command_attrs);
+        g_debug ("  command_attrs: %p", objid (self->command_attrs));
         break;
     case PROP_CONNECTION_MANAGER:
         self->connection_manager = CONNECTION_MANAGER (g_value_get_object (value));
@@ -126,7 +126,7 @@ command_source_set_property (GObject       *object,
         }
         self->sink = SINK (g_value_get_object (value));
         g_object_ref (self->sink);
-        g_debug ("  sink: 0x%" PRIxPTR, (uintptr_t)self->sink);
+        g_debug ("  sink: %p", objid (self->sink));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -142,7 +142,7 @@ command_source_get_property (GObject      *object,
 {
     CommandSource *self = COMMAND_SOURCE (object);
 
-    g_debug ("command_source_get_properties: 0x%" PRIxPTR, (uintptr_t)self);
+    g_debug ("command_source_get_properties: %p", objid (self));
     switch (property_id) {
     case PROP_COMMAND_ATTRS:
         g_value_set_object (value, self->command_attrs);
@@ -181,18 +181,17 @@ command_source_on_input_ready (GInputStream *istream,
     uint8_t       *buf;
     size_t         buf_size;
 
-    g_debug ("%s: GInputStream: 0x%" PRIxPTR ", CommandSource: 0x%" PRIxPTR,
-             __func__, (uintptr_t)istream, (uintptr_t)data->self);
+    g_debug ("%s: GInputStream: %p, CommandSource: %p",
+             __func__, objid (istream), objid (data->self));
     connection =
         connection_manager_lookup_istream (data->self->connection_manager,
                                            istream);
     if (connection == NULL) {
-        g_error ("failed to get connection associated with istream: 0x%"
-                 PRIxPTR, (uintptr_t)istream);
+        g_error ("failed to get connection associated with istream: %p",
+                 objid (istream));
     } else {
-        g_debug ("connection_manager_lookup_socket for socket: 0x%" PRIxPTR
-                 ", connection: 0x%" PRIxPTR, (uintptr_t)istream,
-                 (uintptr_t)connection);
+        g_debug ("connection_manager_lookup_socket for socket: %p, "
+                 "connection: %p", objid (istream), objid (connection));
     }
     buf = read_tpm_buffer_alloc (istream, &buf_size);
     if (buf == NULL) {
@@ -214,10 +213,8 @@ fail_out:
     if (buf != NULL) {
         g_free (buf);
     }
-    g_debug ("removing connection 0x%" PRIxPTR " from connection_manager "
-             "0x%" PRIxPTR,
-             (uintptr_t)connection,
-             (uintptr_t)data->self->connection_manager);
+    g_debug ("removing connection %p from connection_manager %p",
+             objid (connection), objid (data->self->connection_manager));
     connection_manager_remove (data->self->connection_manager,
                                connection);
     ControlMessage *msg =
@@ -232,7 +229,7 @@ fail_out:
      * since we're letting this source die at the end of this function
      * (returning FALSE).
      */
-    g_debug ("%s: reomvingunref GCancellable: 0x%" PRIxPTR, __func__, (uintptr_t)data->cancellable);
+    g_debug ("%s: reomvingunref GCancellable: %p", __func__, objid (data->cancellable));
     g_hash_table_remove (data->self->istream_to_source_data_map, istream);
     return G_SOURCE_REMOVE;
 }
@@ -251,7 +248,7 @@ command_source_on_new_connection (ConnectionManager   *connection_manager,
     source_data_t *data;
     UNUSED_PARAM(connection_manager);
 
-    g_info ("%s: adding new connection: 0x%" PRIxPTR, __func__, (uintptr_t)connection);
+    g_info ("%s: adding new connection: %p", __func__, objid (connection));
     /*
      * Take reference to socket, will be freed when the source_data_t
      * structure is freed
@@ -295,9 +292,8 @@ command_source_source_cancel (gpointer key,
     g_debug ("%s", __func__);
     source_data_t *data = (source_data_t*)value;
 
-    g_debug ("%s: canceling cancellable: 0x%" PRIxPTR " and destroying "
-             "source: 0x%" PRIxPTR, __func__, (uintptr_t)data->cancellable,
-             (uintptr_t)data->source);
+    g_debug ("%s: canceling cancellable: %p" " and destroying source: %p",
+             __func__, objid (data->cancellable), objid (data->source));
     g_cancellable_cancel (data->cancellable);
 }
 /*

--- a/src/connection-manager.c
+++ b/src/connection-manager.c
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include "connection-manager.h"
+#include "util.h"
 
 #define MAX_CONNECTIONS 100
 #define MAX_CONNECTIONS_DEFAULT 27
@@ -44,13 +45,11 @@ connection_manager_set_property (GObject        *object,
 {
     ConnectionManager *mgr = CONNECTION_MANAGER (object);
 
-    g_debug ("connection_manager_set_property: 0x%" PRIxPTR,
-             (uintptr_t)mgr);
+    g_debug ("connection_manager_set_property: %p", objid (mgr));
     switch (property_id) {
     case PROP_MAX_CONNECTIONS:
         mgr->max_connections = g_value_get_uint (value);
-        g_debug ("  max_connections: 0x%" PRIxPTR,
-                 (uintptr_t)mgr->max_connections);
+        g_debug ("  max_connections: %u", mgr->max_connections);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -68,7 +67,7 @@ connection_manager_get_property (GObject     *object,
 {
     ConnectionManager *mgr = CONNECTION_MANAGER (object);
 
-    g_debug ("connection_manager_get_property: 0x%" PRIxPTR, (uintptr_t)mgr);
+    g_debug ("connection_manager_get_property: %p", objid (mgr));
     switch (property_id) {
     case PROP_MAX_CONNECTIONS:
         g_value_set_uint (value, mgr->max_connections);
@@ -196,8 +195,8 @@ connection_manager_insert (ConnectionManager    *manager,
         g_error ("Error locking connection_manager mutex: %s",
                  strerror (errno));
     if (connection_manager_is_full (manager)) {
-        g_warning ("connection_manager: 0x%" PRIxPTR " max_connections of %u exceeded",
-                   (uintptr_t)manager, manager->max_connections);
+        g_warning ("connection_manager: %p max_connections of %u exceeded",
+                   objid (manager), manager->max_connections);
         pthread_mutex_unlock (&manager->mutex);
         return -1;
     }
@@ -290,23 +289,23 @@ connection_manager_remove (ConnectionManager   *manager,
 {
     gboolean ret;
 
-    g_debug ("connection_manager 0x%" PRIxPTR " removing Connection 0x%" PRIxPTR,
-             (uintptr_t)manager, (uintptr_t)connection);
+    g_debug ("connection_manager %p removing Connection %p",
+             objid (manager), objid (connection));
     pthread_mutex_lock (&manager->mutex);
     ret = g_hash_table_remove (manager->connection_from_istream_table,
                                connection_key_istream (connection));
     if (ret != TRUE)
-        g_error ("failed to remove Connection 0x%" PRIxPTR " from g_hash_table "
-                 "0x%" PRIxPTR "using key 0x%" PRIxPTR, (uintptr_t)connection,
-                 (uintptr_t)manager->connection_from_istream_table,
-                 (uintptr_t)connection_key_istream (connection));
+        g_error ("failed to remove Connection %p from g_hash_table %p using "
+                 "key %p", objid (connection),
+                 objid (manager->connection_from_istream_table),
+                 objid (connection_key_istream (connection)));
     ret = g_hash_table_remove (manager->connection_from_id_table,
                                connection_key_id (connection));
     if (ret != TRUE)
-        g_error ("failed to remove Connection 0x%" PRIxPTR " from g_hash_table "
-                 "0x%" PRIxPTR " using key %" PRIxPTR, (uintptr_t)connection,
-                 (uintptr_t)manager->connection_from_istream_table,
-                 (uintptr_t)connection_key_id (connection));
+        g_error ("failed to remove Connection %p from g_hash_table %p using "
+                 "key %p", objid (connection),
+                 objid (manager->connection_from_istream_table),
+                 objid (connection_key_id (connection)));
     pthread_mutex_unlock (&manager->mutex);
 
     return ret;

--- a/src/connection.c
+++ b/src/connection.c
@@ -37,20 +37,18 @@ connection_set_property (GObject       *object,
     switch (property_id) {
     case PROP_ID:
         self->id = g_value_get_uint64 (value);
-        g_debug ("Connection 0x%" PRIxPTR " set id to 0x%" PRIx64,
-                 (uintptr_t)self, self->id);
+        g_debug ("Connection %p set id to 0x%" PRIx64, objid (self), self->id);
         break;
     case PROP_IO_STREAM:
         self->iostream = G_IO_STREAM (g_value_dup_object (value));
-        g_debug ("Connection 0x%" PRIxPTR " set socket to %" PRIxPTR,
-                 (uintptr_t)self, (uintptr_t)self->iostream);
+        g_debug ("Connection %p set socket to %p",
+                 objid (self), objid (self->iostream));
         break;
     case PROP_TRANSIENT_HANDLE_MAP:
         self->transient_handle_map = g_value_get_object (value);
         g_object_ref (self->transient_handle_map);
-        g_debug ("Connection 0x%" PRIxPTR " set transient_handle_map to 0x%"
-                  PRIxPTR, (uintptr_t)self,
-                  (uintptr_t)self->transient_handle_map);
+        g_debug ("Connection %p set transient_handle_map to %p",
+                 objid (self), objid (self->transient_handle_map));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);

--- a/src/handle-map-entry.c
+++ b/src/handle-map-entry.c
@@ -84,7 +84,7 @@ handle_map_entry_init (HandleMapEntry *entry)
 static void
 handle_map_entry_finalize (GObject *object)
 {
-    g_debug ("handle_map_entry_finalize: 0x%" PRIxPTR, (uintptr_t)object);
+    g_debug ("handle_map_entry_finalize: %p", objid (object));
     G_OBJECT_CLASS (handle_map_entry_parent_class)->finalize (object);
 }
 /*
@@ -139,8 +139,8 @@ handle_map_entry_new (TPM2_HANDLE phandle,
                                             "phandle", (guint)phandle,
                                             "vhandle", (guint)vhandle,
                                             NULL));
-    g_debug ("handle_map_entry_new: 0x%" PRIxPTR " with vhandle: 0x%" PRIx32
-             " and phandle: 0x%" PRIx32, (uintptr_t)entry, vhandle, phandle);
+    g_debug ("handle_map_entry_new: %p" " with vhandle: 0x%" PRIx32
+             " and phandle: 0x%" PRIx32, objid (entry), vhandle, phandle);
     return entry;
 }
 /*

--- a/src/handle-map.c
+++ b/src/handle-map.c
@@ -8,6 +8,7 @@
 #include <inttypes.h>
 
 #include "handle-map.h"
+#include "util.h"
 
 G_DEFINE_TYPE (HandleMap, handle_map, G_TYPE_OBJECT);
 
@@ -58,7 +59,8 @@ handle_map_set_property (GObject        *object,
         break;
     case PROP_MAX_ENTRIES:
         map->max_entries = g_value_get_uint (value);
-        g_debug ("handle_map_set_property: 0x%" PRIxPTR " max-entries: %u", (intptr_t)map, map->max_entries);
+        g_debug ("handle_map_set_property: %p max-entries: %u", objid (map),
+                 map->max_entries);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -208,12 +210,12 @@ handle_map_insert (HandleMap      *map,
                    TPM2_HANDLE      vhandle,
                    HandleMapEntry *entry)
 {
-    g_debug ("handle_map_insert: vhandle: 0x%" PRIx32 ", entry: 0x%" PRIxPTR,
-             vhandle, (uintptr_t)entry);
+    g_debug ("handle_map_insert: vhandle: 0x%" PRIx32 ", entry: %p",
+             vhandle, objid (entry));
     handle_map_lock (map);
     if (handle_map_is_full (map)) {
-        g_warning ("HandleMap: 0x%" PRIxPTR " max_entries of %u exceeded",
-                   (uintptr_t)map, map->max_entries);
+        g_warning ("HandleMap: %p" " max_entries of %u exceeded",
+                   objid (map), map->max_entries);
         handle_map_unlock (map);
         return FALSE;
     }

--- a/src/ipc-frontend-dbus.c
+++ b/src/ipc-frontend-dbus.c
@@ -461,8 +461,8 @@ on_handle_cancel (TctiTabrmd            *skeleton,
                                                "No connection.");
         return TRUE;
     }
-    g_info ("canceling command for connection 0x%" PRIxPTR " with "
-            "id_pid_mix: 0x%" PRIx64, (uintptr_t)connection, id_pid_mix);
+    g_info ("canceling command for connection %p" " with "
+            "id_pid_mix: 0x%" PRIx64, objid (connection), id_pid_mix);
     /* cancel any existing commands for the connection */
     g_dbus_method_invocation_return_error (invocation,
                                            TABRMD_ERROR,
@@ -515,9 +515,8 @@ on_handle_set_locality (TctiTabrmd            *skeleton,
                                                "No connection.");
         return TRUE;
     }
-    g_info ("setting locality for connection 0x%" PRIxPTR " with "
-            "id_pid_mix: 0x%" PRIx64 " to: %" PRIx8,
-            (uintptr_t)connection, id_pid_mix, locality);
+    g_info ("setting locality for connection %p with id_pid_mix: 0x%" PRIx64
+            " to: %" PRIx8, objid (connection), id_pid_mix, locality);
     /* set locality for an existing connection */
     g_dbus_method_invocation_return_error (invocation,
                                            TABRMD_ERROR,

--- a/src/ipc-frontend.c
+++ b/src/ipc-frontend.c
@@ -69,7 +69,7 @@ void
 ipc_frontend_connect (IpcFrontend *self,
                       GMutex      *init_mutex)
 {
-    g_debug ("ipc_frontend_connect: 0x%" PRIxPTR, (uintptr_t)self);
+    g_debug ("ipc_frontend_connect: %p", objid (self));
     IPC_FRONTEND_GET_CLASS (self)->connect (self, init_mutex);
 }
 /*
@@ -82,7 +82,7 @@ ipc_frontend_connect (IpcFrontend *self,
 void
 ipc_frontend_disconnect (IpcFrontend *self)
 {
-    g_debug ("ipc_frontend_disconnect: 0x%" PRIxPTR, (uintptr_t)self);
+    g_debug ("ipc_frontend_disconnect: %p", objid (self));
     IPC_FRONTEND_GET_CLASS (self)->disconnect (self);
 }
 void

--- a/src/message-queue.c
+++ b/src/message-queue.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "message-queue.h"
+#include "util.h"
 
 G_DEFINE_TYPE (MessageQueue, message_queue, G_TYPE_OBJECT);
 
@@ -65,8 +66,8 @@ message_queue_enqueue (MessageQueue  *message_queue,
                        GObject       *object)
 {
     g_assert (message_queue != NULL);
-    g_debug ("message_queue_enqueue 0x%" PRIxPTR " : message 0x%" PRIxPTR,
-             (uintptr_t)message_queue, (uintptr_t)object);
+    g_debug ("message_queue_enqueue %p : message %p",
+             objid (message_queue), objid (object));
     g_object_ref (object);
     g_async_queue_push (message_queue->queue, object);
 }
@@ -81,8 +82,8 @@ message_queue_dequeue (MessageQueue *message_queue)
     GObject *obj;
 
     g_assert (message_queue != NULL);
-    g_debug ("message_queue_dequeue 0x%" PRIxPTR, (uintptr_t)message_queue);
+    g_debug ("message_queue_dequeue %p", objid (message_queue));
     obj = g_async_queue_pop (message_queue->queue);
-    g_debug ("  got obj: 0x%" PRIxPTR, (uintptr_t)obj);
+    g_debug ("  got obj: %p", objid (obj));
     return obj;
 }

--- a/src/random.c
+++ b/src/random.c
@@ -99,7 +99,6 @@ random_seed_from_file (Random *random,
         ret = -1;
         goto close_out;
     }
-    g_debug ("seeding rand with %ld", rand_seed);
     random->rand_state[0] = 0x330E;
     random->rand_state[1] = rand_seed & 0xffff;
     random->rand_state[2] = (rand_seed >> 16) & 0xffff;
@@ -127,7 +126,6 @@ random_get_bytes (Random    *random,
     size_t i;
     uint8_t rand[sizeof (long int)] = { 0, };
 
-    g_debug ("random_get_bytes: %p", random);
     g_assert_nonnull (random);
     assert (random->rand_state);
     for (i = 0; i < count; ++i) {

--- a/src/response-sink.c
+++ b/src/response-sink.c
@@ -82,7 +82,7 @@ response_sink_get_property (GObject     *object,
 {
     ResponseSink *self = RESPONSE_SINK (object);
 
-    g_debug ("response_sink_get_property: 0x%" PRIxPTR, (uintptr_t)self);
+    g_debug ("%s: %p", __func__, objid (self));
     switch (property_id) {
     case PROP_IN_QUEUE:
         g_value_set_object (value, self->in_queue);
@@ -101,7 +101,7 @@ response_sink_dispose (GObject *obj)
     ResponseSink *sink = RESPONSE_SINK (obj);
     Thread *thread = THREAD (obj);
 
-    g_debug ("%s: 0x%" PRIxPTR, __func__, (uintptr_t)obj);
+    g_debug ("%s: %p", __func__, objid (obj));
     if (sink == NULL)
         g_error ("%s: passed NULL pointer", __func__);
     if (thread->thread_id != 0)
@@ -123,10 +123,9 @@ response_sink_unblock (Thread *self)
     ControlMessage *msg;
 
     if (sink == NULL)
-        g_error ("response_sink_cancel passed NULL sink");
+        g_error ("%s: passed NULL sink", __func__);
     msg = control_message_new (CHECK_CANCEL);
-    g_debug ("response_sink_cancel enqueuing ControlMessage: 0x%" PRIxPTR,
-             (uintptr_t)msg);
+    g_debug ("%s: enqueuing ControlMessage: %p", __func__, objid (msg));
     message_queue_enqueue (sink->in_queue, G_OBJECT (msg));
     g_object_unref (msg);
 }
@@ -190,8 +189,7 @@ response_sink_process_response (Tpm2Response *response)
     GIOStream   *iostream = connection_get_iostream (connection);
     GOutputStream *ostream = g_io_stream_get_output_stream (iostream);
 
-    g_debug ("response_sink_thread got response: 0x%" PRIxPTR " size %d",
-             (uintptr_t)response, size);
+    g_debug ("%s: got response: %p size %d", __func__, objid (response), size);
     g_debug ("  writing 0x%x bytes", size);
     g_debug_bytes (buffer, size, 16, 4);
     written = write_all (ostream, buffer, size);
@@ -232,10 +230,10 @@ response_sink_thread (void *data)
     gboolean done = FALSE;
 
     while (!done) {
-        g_debug ("response_sink_thread blocking on input queue: 0x%" PRIxPTR,
-                 (uintptr_t)sink->in_queue);
+        g_debug ("%s: blocking on input queue: %p", __func__,
+                 objid (sink->in_queue));
         obj = message_queue_dequeue (sink->in_queue);
-        g_debug ("response_sink_thread got obj: 0x%" PRIxPTR, (uintptr_t)obj);
+        g_debug ("%s: got obj: %p", __func__, objid (obj));
         if (IS_TPM2_RESPONSE (obj)) {
             response_sink_process_response (TPM2_RESPONSE (obj));
         } else if (IS_CONTROL_MESSAGE (obj)) {

--- a/src/session-entry.c
+++ b/src/session-entry.c
@@ -99,7 +99,7 @@ session_entry_dispose (GObject *object)
 {
     SessionEntry *entry = SESSION_ENTRY (object);
 
-    g_debug ("%s: 0x%" PRIxPTR, __func__, (uintptr_t)entry);
+    g_debug ("%s: %p", __func__, objid (entry));
     g_clear_object (&entry->connection);
     G_OBJECT_CLASS (session_entry_parent_class)->dispose (object);
 }
@@ -153,8 +153,8 @@ SessionEntry*
 session_entry_new (Connection *connection,
                    TPM2_HANDLE  handle)
 {
-    g_debug ("session_entry_new with connection: 0x%" PRIxPTR,
-             (uintptr_t)connection);
+    g_debug ("session_entry_new with connection: %p",
+             objid (connection));
     return SESSION_ENTRY (g_object_new (TYPE_SESSION_ENTRY,
                                         "connection", connection,
                                         "handle", handle,
@@ -204,8 +204,8 @@ get_handle (size_buf_t *size_buf)
                                         &offset,
                                         &handle);
     if (rc != TSS2_RC_SUCCESS) {
-        g_debug ("%s: Failed to unmarshal handle from size_buf_t 0x%"
-                   PRIxPTR, __func__, (uintptr_t)size_buf);
+        g_debug ("%s: Failed to unmarshal handle from size_buf_t %p",
+                 __func__, objid (size_buf));
         return 0;
     }
     g_debug ("%s: unmarshalled handle 0x08%" PRIx32, __func__, handle);
@@ -218,14 +218,14 @@ TPM2_HANDLE
 session_entry_get_handle (SessionEntry *entry)
 {
     g_assert_nonnull (entry);
-    g_debug ("%s: with SessionEntry 0x%" PRIxPTR, __func__, (uintptr_t)entry);
+    g_debug ("%s: with SessionEntry %p", __func__, objid (entry));
     return entry->handle;
 }
 TPM2_HANDLE
 session_entry_get_context_client_handle (SessionEntry *entry)
 {
     g_assert_nonnull (entry);
-    g_debug ("%s: with SessionEntry 0x%" PRIxPTR, __func__, (uintptr_t)entry);
+    g_debug ("%s: with SessionEntry %p", __func__, objid (entry));
     return get_handle (session_entry_get_context_client (entry));
 }
 /*
@@ -292,13 +292,12 @@ session_entry_clear_connection (SessionEntry *entry)
 void
 session_entry_prettyprint (SessionEntry *entry)
 {
-    g_debug ("SessionEntry:    0x%"   PRIxPTR, (uintptr_t)entry);
-    g_debug ("  Connection:    0x%"   PRIxPTR, (uintptr_t)entry->connection);
-    g_debug ("  State:         %s",   session_entry_state_to_str (entry->state));
-    g_debug ("  context:       0x%"   PRIxPTR,
-             (uintptr_t)session_entry_get_context (entry));
-    g_debug ("  context_client:0x%"   PRIxPTR,
-             (uintptr_t)session_entry_get_context_client (entry));
+    g_debug ("SessionEntry:    %p", objid (entry));
+    g_debug ("  Connection:    %p", objid (entry->connection));
+    g_debug ("  State:         %s", session_entry_state_to_str (entry->state));
+    g_debug ("  context:       %p", objid (session_entry_get_context (entry)));
+    g_debug ("  context_client:%p",
+             objid (session_entry_get_context_client (entry)));
 }
 /*
  * This function is used with the g_list_find_custom function to find
@@ -397,8 +396,8 @@ session_entry_compare_on_context_client (SessionEntry *entry,
 {
     size_buf_t *size_buf = NULL;
 
-    g_debug ("%s: SessionEntry 0x%" PRIxPTR ", buf 0x%" PRIxPTR " and size "
-             "0x%zx", __func__, (uintptr_t)entry, (uintptr_t)buf, size);
+    g_debug ("%s: SessionEntry %p, buf %p and size 0x%zx", __func__,
+             objid (entry), objid (buf), size);
     g_assert (size <= SIZE_BUF_MAX);
     size_buf = session_entry_get_context_client (entry);
     return memcmp (size_buf->buf, buf, size);

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -83,7 +83,7 @@ static void
 on_ipc_frontend_disconnect (IpcFrontend *ipc_frontend,
                             GMainLoop   *loop)
 {
-    g_info ("IpcFrontend 0x%" PRIxPTR " disconnected", (uintptr_t)ipc_frontend);
+    g_info ("%s: IpcFrontend %p disconnected", __func__, objid (ipc_frontend));
     main_loop_quit (loop);
 }
 /**
@@ -133,7 +133,7 @@ init_thread_func (gpointer user_data)
     connection_manager = connection_manager_new(data->options.max_connections);
     if (connection_manager == NULL)
         g_error ("failed to allocate connection_manager");
-    g_debug ("ConnectionManager: 0x%" PRIxPTR, (uintptr_t)connection_manager);
+    g_debug ("%s: ConnectionManager: %p", __func__, objid (connection_manager));
     /* setup IpcFrontend */
     data->ipc_frontend =
         IPC_FRONTEND (ipc_frontend_dbus_new (data->options.bus,
@@ -161,8 +161,8 @@ init_thread_func (gpointer user_data)
     }
     g_clear_object (&tcti_factory);
     data->access_broker = access_broker_new (tcti);
-    g_debug ("created AccessBroker: 0x%" PRIxPTR,
-             (uintptr_t)data->access_broker);
+    g_debug ("%s: created AccessBroker: %p", __func__,
+             objid (data->access_broker));
     g_clear_object (&tcti);
     rc = access_broker_init_tpm (data->access_broker);
     if (rc != TSS2_RC_SUCCESS)
@@ -175,27 +175,27 @@ init_thread_func (gpointer user_data)
      * pipeline.
      */
     command_attrs = command_attrs_new ();
-    g_debug ("created CommandAttrs: 0x%" PRIxPTR, (uintptr_t)command_attrs);
+    g_debug ("%s: created CommandAttrs: %p", __func__, objid (command_attrs));
     ret = command_attrs_init_tpm (command_attrs, data->access_broker);
     if (ret != 0)
-        g_error ("failed to initialize CommandAttribute object: 0x%" PRIxPTR,
-                 (uintptr_t)command_attrs);
+        g_error ("%s: failed to initialize CommandAttribute object: %p",
+                 __func__, objid (command_attrs));
 
     data->command_source =
         command_source_new (connection_manager, command_attrs);
     g_object_unref (connection_manager);
-    g_debug ("created command source: 0x%" PRIxPTR,
-             (uintptr_t)data->command_source);
+    g_debug ("%s: created command source: %p", __func__,
+             objid (data->command_source));
     session_list = session_list_new (data->options.max_sessions,
                                      SESSION_LIST_MAX_ABANDONED_DEFAULT);
     data->resource_manager = resource_manager_new (data->access_broker,
                                                    session_list);
     g_clear_object (&session_list);
-    g_debug ("created ResourceManager: 0x%" PRIxPTR,
-             (uintptr_t)data->resource_manager);
+    g_debug ("%s: created ResourceManager: %p", __func__,
+             objid (data->resource_manager));
     data->response_sink = response_sink_new ();
-    g_debug ("created response source: 0x%" PRIxPTR,
-             (uintptr_t)data->response_sink);
+    g_debug ("%s: created response source: %p", __func__,
+             objid (data->response_sink));
     g_object_unref (command_attrs);
     g_object_unref (data->access_broker);
     /**
@@ -426,6 +426,7 @@ main (int argc, char *argv[])
     gmain_data_t gmain_data = { .options = TABRMD_OPTIONS_INIT_DEFAULT };
     GThread *init_thread;
 
+    util_init ();
     g_info ("tabrmd startup");
     parse_opts (argc, argv, &gmain_data.options);
     if (geteuid() == 0 && ! gmain_data.options.allow_root) {

--- a/src/tcti-factory.c
+++ b/src/tcti-factory.c
@@ -137,8 +137,8 @@ tcti_factory_create (TctiFactory *self)
     const TSS2_TCTI_INFO *info;
     TSS2_TCTI_CONTEXT *ctx;
 
-    g_debug ("%s: TctiFactory 0x%" PRIxPTR " with TCTI '%s' and conf '%s'",
-             __func__, (uintptr_t)self, self->name, self->conf);
+    g_debug ("%s: TctiFactory %p with TCTI '%s' and conf '%s'",
+             __func__, objid (self), self->name, self->conf);
     rc = tcti_util_discover_info (self->name,
                                   &info,
                                   &dl_handle);

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -45,8 +45,7 @@ tss2_tcti_tabrmd_transmit (TSS2_TCTI_CONTEXT *context,
     }
     g_debug_bytes (command, size, 16, 4);
     ostream = g_io_stream_get_output_stream (TSS2_TCTI_TABRMD_IOSTREAM (context));
-    g_debug ("blocking write on iostream: 0x%" PRIxPTR,
-             (uintptr_t)ostream);
+    g_debug ("%s: blocking write on ostream", __func__);
     write_ret = write_all (ostream, command, size);
     /* should switch on possible errors to translate to TSS2 error codes */
     switch (write_ret) {
@@ -449,8 +448,6 @@ tabrmd_kv_callback (const key_value_t *key_value,
 {
     tabrmd_conf_t *tabrmd_conf = (tabrmd_conf_t*)user_data;
 
-    g_debug ("%s with key_value: 0x%" PRIxPTR " and user_data: 0x%" PRIxPTR,
-             __func__, (uintptr_t)key_value, (uintptr_t)user_data);
     if (key_value == NULL || user_data == NULL) {
         g_warning ("%s passed NULL parameter", __func__);
         return TSS2_TCTI_RC_GENERAL_FAILURE;

--- a/src/tcti.c
+++ b/src/tcti.c
@@ -53,7 +53,7 @@ tcti_get_property (GObject     *object,
 {
     Tcti *self = TCTI (object);
 
-    g_debug ("%s: 0x%" PRIxPTR, __func__, (uintptr_t)self);
+    g_debug ("%s: %p", __func__, objid (self));
     switch (property_id) {
     case PROP_CONTEXT:
         g_value_set_pointer (value, self->tcti_context);
@@ -72,7 +72,7 @@ tcti_dispose (GObject *object)
 {
     Tcti *self = TCTI (object);
 
-    g_debug ("%s: Tcti 0x%" PRIxPTR, __func__, (uintptr_t)self);
+    g_debug ("%s: Tcti %p", __func__, objid (self));
     if (self->tcti_context) {
         Tss2_Tcti_Finalize (self->tcti_context);
     }
@@ -83,7 +83,7 @@ tcti_finalize (GObject *object)
 {
     Tcti *self = TCTI (object);
 
-    g_debug ("%s: Tcti 0x%" PRIxPTR, __func__, (uintptr_t)self);
+    g_debug ("%s: Tcti %p", __func__, objid (self));
 #if !defined (DISABLE_DLCLOSE)
     g_clear_pointer (&self->tcti_dl_handle, dlclose);
 #endif
@@ -135,7 +135,7 @@ tcti_new (TSS2_TCTI_CONTEXT *tcti_context,
 TSS2_TCTI_CONTEXT*
 tcti_peek_context (Tcti *self)
 {
-    g_debug ("tcti_peek_context: 0x%" PRIxPTR, (uintptr_t)self);
+    g_debug ("%s: %p", __func__, objid (self));
     return self->tcti_context;
 }
 /**

--- a/src/tpm2-command.c
+++ b/src/tpm2-command.c
@@ -162,7 +162,7 @@ tpm2_command_get_property (GObject     *object,
 {
     Tpm2Command *self = TPM2_COMMAND (object);
 
-    g_debug ("tpm2_command_get_property: 0x%" PRIxPTR, (uintptr_t)self);
+    g_debug ("%s: %p", __func__, objid (self));
     switch (property_id) {
     case PROP_ATTRIBUTES:
         g_value_set_uint (value, self->attributes);
@@ -186,7 +186,7 @@ tpm2_command_dispose (GObject *obj)
 {
     Tpm2Command *cmd = TPM2_COMMAND (obj);
 
-    g_debug ("%s: Tpm2Command 0x%" PRIxPTR, __func__, (uintptr_t)cmd);
+    g_debug ("%s: Tpm2Command %p", __func__, objid (cmd));
     g_clear_object (&cmd->connection);
     G_OBJECT_CLASS (tpm2_command_parent_class)->dispose (obj);
 }
@@ -640,8 +640,8 @@ tpm2_command_get_auths_size (Tpm2Command *command)
         return 0;
     }
     if (!tpm2_command_has_auths (command)) {
-        g_warning ("tpm2_command_get_auths_size, Tpm2Command 0x%" PRIxPTR
-                   " has no auths", (uintptr_t)command);
+        g_warning ("%s: Tpm2Command %p has no auths",
+                   __func__, objid (command));
         return 0;
     }
     auth_size_end = AUTH_AREA_SIZE_END_OFFSET (command);
@@ -725,11 +725,9 @@ tpm2_command_foreach_auth (Tpm2Command *command,
          offset = AUTH_AUTH_BUF_END_OFFSET   (command, offset))
     {
         size_t offset_tmp = offset;
-        g_debug ("invoking callback at 0x%" PRIxPTR " with authorization at "
-                 "offset: %zu and user data: 0x%" PRIxPTR,
-                 (uintptr_t)callback,
-                 offset_tmp,
-                 (uintptr_t)user_data);
+        g_debug ("%s: invoking callback at %p with authorization at offset: "
+                 "%zu and user data: %p", __func__, objid (callback),
+                 offset_tmp, objid (user_data));
         callback (&offset_tmp, user_data);
     }
 

--- a/src/tpm2-response.c
+++ b/src/tpm2-response.c
@@ -88,7 +88,7 @@ tpm2_response_get_property (GObject     *object,
 {
     Tpm2Response *self = TPM2_RESPONSE (object);
 
-    g_debug ("tpm2_response_get_property: 0x%" PRIxPTR, (uintptr_t)self);
+    g_debug ("%s: %p", __func__, objid (self));
     switch (property_id) {
     case PROP_ATTRIBUTES:
         g_value_set_uint (value, self->attributes);
@@ -112,7 +112,7 @@ tpm2_response_dispose (GObject *obj)
 {
     Tpm2Response *self = TPM2_RESPONSE (obj);
 
-    g_debug ("%s: Tpm2Response: 0x%" PRIxPTR, __func__, (uintptr_t)self);
+    g_debug ("%s: Tpm2Response: %p", __func__, objid (self));
     g_clear_object (&self->connection);
     G_OBJECT_CLASS (tpm2_response_parent_class)->dispose (obj);
 }
@@ -191,8 +191,9 @@ tpm2_response_new (Connection     *connection,
                    size_t           buffer_size,
                    TPMA_CC          attributes)
 {
-    g_debug ("%s: connection: 0x%" PRIxPTR " buffer: 0x%" PRIxPTR " size: 0x%zx attrs: 0x%" PRIx32,
-             __func__, (uintptr_t)connection, (uintptr_t)buffer, buffer_size, attributes);
+    g_debug ("%s: connection: %p buffer: %p size: 0x%zx attrs: 0x%" PRIx32,
+             __func__, objid (connection), objid (buffer), buffer_size,
+             attributes);
     return TPM2_RESPONSE (g_object_new (TYPE_TPM2_RESPONSE,
                                         "attributes", attributes,
                                        "buffer",  buffer,
@@ -253,10 +254,11 @@ tpm2_response_new_context_load (Connection *connection,
                    __func__, rc);
         goto out;
     }
-    g_debug ("%s: Generating response for SaveContext from connection 0x%" PRIxPTR, __func__, (uintptr_t)connection);
+    g_debug ("%s: generating response for SaveContext from connection %p",
+             __func__, objid (connection));
     response = tpm2_response_new (connection, buf, offset, 0x10000161);
-    g_debug ("%s generated Tpm2Response object: 0x%" PRIxPTR " for connection: 0x%" PRIxPTR,
-             __func__, (uintptr_t)response, (uintptr_t)connection);
+    g_debug ("%s: generated Tpm2Response object: %p for connection: %p",
+             __func__, objid (response), objid (connection));
 out:
     if (response == NULL) {
         g_free (buf);
@@ -294,10 +296,11 @@ tpm2_response_new_context_save (Connection *connection,
                    __func__, rc);
         goto out;
     }
-    g_debug ("%s: Generating response for SaveContext from connection 0x%" PRIxPTR, __func__, (uintptr_t)connection);
+    g_debug ("%s: generating response for SaveContext from connection %p",
+             __func__, objid (connection));
     response = tpm2_response_new (connection, buf, TPM_HEADER_SIZE + size_buf->size, 0x02000162);
-    g_debug ("%s generated Tpm2Response object: 0x%" PRIxPTR " for connection: 0x%" PRIxPTR,
-             __func__, (uintptr_t)response, (uintptr_t)connection);
+    g_debug ("%s generated Tpm2Response object: %p for connection: %p",
+             __func__, objid (response), objid (connection));
 out:
     if (response == NULL) {
         g_free (buf);

--- a/src/util.h
+++ b/src/util.h
@@ -92,5 +92,7 @@ void        g_debug_tpma_cc                 (TPMA_CC           tpma_cc);
 TSS2_RC     parse_key_value_string (char *kv_str,
                                     KeyValueFunc callback,
                                     gpointer user_data);
+void util_init (void);
+void* objid (const void* ptr);
 
 #endif /* UTIL_H */

--- a/test/access-broker_unit.c
+++ b/test/access-broker_unit.c
@@ -342,6 +342,7 @@ access_broker_send_command_success (void **state)
 int
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (access_broker_type_test,
                                          access_broker_setup,

--- a/test/command-attrs_unit.c
+++ b/test/command-attrs_unit.c
@@ -268,6 +268,7 @@ command_attrs_from_cc_fail_test (void **state)
 gint
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (command_attrs_type_test,
                                          command_attrs_setup,

--- a/test/command-source_unit.c
+++ b/test/command-source_unit.c
@@ -344,6 +344,7 @@ command_source_on_io_ready_eof_test (void **state)
 int
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (command_source_allocate_test,
                                          command_source_allocate_setup,

--- a/test/connection-manager_unit.c
+++ b/test/connection-manager_unit.c
@@ -138,6 +138,7 @@ connection_manager_remove_test (void **state)
 int
 main(void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (connection_manager_allocate_test),
         cmocka_unit_test_setup_teardown (connection_manager_insert_test,

--- a/test/connection_unit.c
+++ b/test/connection_unit.c
@@ -167,6 +167,7 @@ connection_server_to_client_test (void **state)
 int
 main(void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (connection_allocate_test),
         cmocka_unit_test_setup_teardown (connection_key_socket_test,

--- a/test/handle-map-entry_unit.c
+++ b/test/handle-map-entry_unit.c
@@ -10,6 +10,7 @@
 #include <cmocka.h>
 
 #include "handle-map-entry.h"
+#include "util.h"
 
 #define PHANDLE 0xdeadbeef
 #define VHANDLE 0xfeebdaed
@@ -88,6 +89,7 @@ handle_map_entry_get_vhandle_test (void **state)
 gint
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (handle_map_entry_type_test,
                                          handle_map_entry_setup,

--- a/test/handle-map_unit.c
+++ b/test/handle-map_unit.c
@@ -10,6 +10,7 @@
 
 #include "handle-map.h"
 #include "handle-map-entry.h"
+#include "util.h"
 
 #define PHANDLE 0xdeadbeef
 #define VHANDLE 0xfeebdaed
@@ -137,6 +138,7 @@ handle_map_next_vhandle_test (void **state)
 int
 main(void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (handle_map_type_test,
                                          handle_map_setup_base,

--- a/test/integration/main.c
+++ b/test/integration/main.c
@@ -12,6 +12,7 @@
 #include "test.h"
 #include "test-options.h"
 #include "context-util.h"
+#include "util.h"
 
 /**
  * This program is a template for integration tests (ones that use the TCTI
@@ -27,6 +28,7 @@ main ()
     int ret;
     test_opts_t opts = TEST_OPTS_DEFAULT_INIT;
 
+    util_init ();
     get_test_opts_from_env (&opts);
     if (sanity_check_test_opts (&opts) != 0)
         exit (1);

--- a/test/ipc-frontend-dbus_unit.c
+++ b/test/ipc-frontend-dbus_unit.c
@@ -10,6 +10,7 @@
 #include <cmocka.h>
 
 #include "ipc-frontend-dbus.h"
+#include "util.h"
 
 static int
 ipc_frontend_dbus_setup (void **state)
@@ -64,6 +65,7 @@ ipc_frontend_dbus_type_test (void **state)
 gint
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (ipc_frontend_dbus_type_test,
                                          ipc_frontend_dbus_setup,

--- a/test/ipc-frontend_unit.c
+++ b/test/ipc-frontend_unit.c
@@ -200,6 +200,7 @@ ipc_frontend_disconnect_test (void **state)
 gint
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (ipc_frontend_type_test,
                                          ipc_frontend_setup,

--- a/test/message-queue_unit.c
+++ b/test/message-queue_unit.c
@@ -149,6 +149,7 @@ message_queue_thread_unblock_test (void **state)
 int
 main(void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (message_queue_allocate_test),
         cmocka_unit_test_setup_teardown (message_queue_enqueue_dequeue_test,

--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -498,6 +498,7 @@ resource_manager_getcap_gap_max_test (void **state)
 int
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (resource_manager_type_test,
                                          resource_manager_setup,

--- a/test/response-sink_unit.c
+++ b/test/response-sink_unit.c
@@ -29,6 +29,7 @@ response_sink_allocate_test (void **state)
 int
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (response_sink_allocate_test),
     };

--- a/test/session-entry_unit.c
+++ b/test/session-entry_unit.c
@@ -111,6 +111,7 @@ session_entry_get_handle_test (void **state)
 gint
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (session_entry_type_test,
                                          session_entry_setup,

--- a/test/session-list_unit.c
+++ b/test/session-list_unit.c
@@ -307,6 +307,7 @@ session_list_claim_fail_test (void **state)
 gint
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (session_list_type_test,
                                          session_list_setup,

--- a/test/tcti-factory_unit.c
+++ b/test/tcti-factory_unit.c
@@ -128,6 +128,7 @@ tcti_factory_create_test (void **state)
 gint
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (tcti_factory_type_test,
                                          tcti_factory_setup,

--- a/test/tcti_unit.c
+++ b/test/tcti_unit.c
@@ -96,6 +96,7 @@ tcti_receive_test (void **state)
 gint
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (tcti_type_test,
                                          tcti_setup,

--- a/test/tpm2-command_unit.c
+++ b/test/tpm2-command_unit.c
@@ -628,6 +628,7 @@ tpm2_command_get_cap_no_count (void **state)
 gint
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (tpm2_command_type_test,
                                          tpm2_command_setup,

--- a/test/tpm2-response_unit.c
+++ b/test/tpm2-response_unit.c
@@ -411,6 +411,7 @@ tpm2_response_set_handle_no_handle_test (void **state)
 gint
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (tpm2_response_type_test,
                                          tpm2_response_setup,

--- a/test/tss2-tcti-tabrmd_unit.c
+++ b/test/tss2-tcti-tabrmd_unit.c
@@ -1414,6 +1414,7 @@ tcti_tabrmd_set_locality_bad_sequence_test (void **state)
 int
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (tcti_tabrmd_init_size_test),
         cmocka_unit_test (tcti_tabrmd_init_success_return_value_test),

--- a/test/util_unit.c
+++ b/test/util_unit.c
@@ -668,6 +668,7 @@ read_tpm_buf_alloc_eof_test (void **state)
 gint
 main (void)
 {
+    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (write_in_one),
         cmocka_unit_test (write_in_two),


### PR DESCRIPTION
Dumping the address of a GObject in debug output is useful as a
mechanism for tracking objects. This effectively uses the address of the
object as an ID value. This is however undesirable as there is a
possibility that a system may be deployed with debug output turned on
mistakenly. This would case the log file to contain info that may be
used to weaken ASLR.

To combat this we add a new function to the util module that we use to
mask object addresses. This is done by combining the address with a
random value using the bitwise exclusive or (aka XOR) operation. The
random value / seed is initialized by adding another new function to
initialize the 'util' module. This function must be called before any
addresses are masked.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>