### PR TITLE
Fix building with clang after recent commits

### DIFF
--- a/src/resource-manager.c
+++ b/src/resource-manager.c
@@ -985,7 +985,7 @@ get_cap_post_process (Tpm2Response *resp)
     g_assert (resp != NULL);
     g_assert (tpm2_response_get_code (resp) == TSS2_RC_SUCCESS);
 
-    TPMS_CAPABILITY_DATA cap_data = { 0 };
+    TPMS_CAPABILITY_DATA cap_data = { .capability = 0 };
     TSS2_RC rc;
     uint8_t *buf = tpm2_response_get_buffer (resp);
     size_t buf_size = tpm2_response_get_size (resp);


### PR DESCRIPTION
When building with clang (as we do in the tpm2-tools Travis CI) we observe the
following error:

src/resource-manager.c:988:41: error: missing field 'data' initializer [-Werror,-Wmissing-field-initializers]
    TPMS_CAPABILITY_DATA cap_data = { 0 };
