### PR TITLE
build: update to ax_code_coverage.m4 version 2019.01.06

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ AUTHORS
 Makefile
 Makefile.in
 aclocal.m4
+aminclude_static.am
 autom4te.cache/
 compile
 config.guess

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,9 @@ matrix:
 install:
   - pip install --user cpp-coveralls
   - mkdir ${DEPS} && pushd ${DEPS}
-  - wget https://download.01.org/tpm2/autoconf-archive-2017.09.28.tar.xz
-  - sha256sum autoconf-archive-2017.09.28.tar.xz | grep -q 5c9fb5845b38b28982a3ef12836f76b35f46799ef4a2e46b48e2bd3c6182fa01
-  - tar xJf autoconf-archive-2017.09.28.tar.xz && pushd autoconf-archive-2017.09.28
+  - wget http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2019.01.06.tar.xz
+  - sha256sum autoconf-archive-2019.01.06.tar.xz | grep -q 17195c833098da79de5778ee90948f4c5d90ed1a0cf8391b4ab348e2ec511e3f
+  - tar xJf autoconf-archive-2019.01.06.tar.xz && pushd autoconf-archive-2019.01.06
   - ./configure --prefix=${PREFIX} && $MAKE && sudo $MAKE install
   - popd # autoconf-archive
   - git clone -b master --single-branch https://github.com/01org/tpm2-tss.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -166,7 +166,22 @@ dbusservicedir   = $(datadir)/dbus-1/system-services
 dbusservice_DATA = dist/com.intel.tss2.Tabrmd.service
 endif # HAVE_SYSTEMD
 
+# ax_code_coverage
+if AUTOCONF_CODE_COVERAGE_2019_01_06
+include $(top_srcdir)/aminclude_static.am
+clean-local: code-coverage-clean
+distclean-local: code-coverage-dist-clean
+
+# workaround for a bug in Autoconf Archive 2019.01.06
+# (https://github.com/autoconf-archive/autoconf-archive/pull/182)
+if CODE_COVERAGE_ENABLED
+AM_DISTCHECK_CONFIGURE_FLAGS := $(AM_DISTCHECK_CONFIGURE_FLAGS) --disable-code-coverage
+endif # CODE_COVERAGE_ENABLED
+
+else # AUTOCONF_CODE_COVERAGE_2019_01_06
 @CODE_COVERAGE_RULES@
+endif # AUTOCONF_CODE_COVERAGE_2019_01_06
+
 @VALGRIND_CHECK_RULES@
 VALGRIND_G_DEBUG = fatal-criticals,gc-friendly
 VALGRIND_memcheck_FLAGS = --leak-check=full --show-leak-kinds=definite,indirect --track-origins=yes --error-exitcode=1

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,11 @@ AS_IF([test ! -x "$(which $GDBUS_CODEGEN)"],
       [AC_MSG_ERROR([*** gdbus-codegen is required to build tpm2-abrmd])])
 
 AX_CODE_COVERAGE
+m4_ifdef([_AX_CODE_COVERAGE_RULES],
+         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [true])],
+         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [false])])
+AX_ADD_AM_MACRO_STATIC([])
+
 # disable helgrind and drd, they hate GAsyncQueue
 AX_VALGRIND_DFLT([sgcheck], [off])
 AX_VALGRIND_DFLT([helgrind], [off])


### PR DESCRIPTION
When using this project in combination with the freshly released Autoconf Archive 2019.01.06, the build fails with a "missing separator" error in the makefile. This is because upstream made a [breaking change](http://git.savannah.nongnu.org/cgit/autoconf-archive.git/commit/m4/ax_code_coverage.m4?id=b5a2d69f7a7e0133733673586231b88464a98d58) by removing `@CODE_COVERAGE_RULES@` and replacing it with `include $(top_srcdir)/aminclude_static.am`, see the [documentation](https://www.gnu.org/software/autoconf-archive/ax_code_coverage.html) for reference.