### PR TITLE
tests: run without X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ script :
         exit 0
     fi
   - $SCANBUILD ./configure $CONFIG_OPTS $CONFIG_EXTRA
-  - dbus-launch $SCANBUILD $MAKE distcheck
+  - $SCANBUILD $MAKE distcheck
   - |
     if [ ! -z "$COVERALLS_REPO_TOKEN" ]; then
       coveralls --build-root=./tpm2-abrmd-*/ --exclude=${DEPS} --exclude=./test --exclude=tpm2-abrmd-$(cat VERSION) --exclude=./coverity --exclude=./src/tabrmd-generated.c --exclude=./src/tabrmd-generated.h --gcov-options '\-lp'

--- a/Makefile.am
+++ b/Makefile.am
@@ -76,7 +76,8 @@ XFAIL_TESTS = \
 TEST_EXTENSIONS = .int
 AM_TESTS_ENVIRONMENT = \
     TEST_FUNC_LIB=$(srcdir)/scripts/int-test-funcs.sh \
-    PATH=./src:$(PATH)
+    PATH=./src:$(PATH) \
+    dbus-run-session
 INT_LOG_COMPILER = $(srcdir)/scripts/int-test-setup.sh
 INT_LOG_FLAGS = --tabrmd-tcti=$(TABRMD_TCTI)
 


### PR DESCRIPTION
Solves:

$ DISPLAY= make check

FAIL: test/tss2-tcti-tabrmd_unit

** (process:17633): CRITICAL **: 23:53:22.403: failed to allocate dbus proxy object:
Error spawning command line ?dbus-launch --autolaunch=4f9189e347d5cdf343

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>