### PR TITLE
ipc-frontend-dbus: only own bus name after intializing dbus_daemon_proxy

### DIFF
--- a/src/ipc-frontend-dbus.c
+++ b/src/ipc-frontend-dbus.c
@@ -649,9 +649,17 @@ on_get_dbus_daemon_proxy (GObject      *source_object,
                    "(org.freedesktop.DBus): %s", error->message);
         g_error_free (error);
         self->dbus_daemon_proxy = NULL;
-    } else {
-        g_debug ("Got proxy object for DBus daemon.");
     }
+    g_debug ("Got proxy object for DBus daemon.");
+
+    self->dbus_name_owner_id = g_bus_own_name (self->bus_type,
+                                               self->bus_name,
+                                               G_BUS_NAME_OWNER_FLAGS_NONE,
+                                               on_bus_acquired,
+                                               on_name_acquired,
+                                               on_name_lost,
+                                               self,
+                                               NULL);
 }
 /*
  * This function overrides the ipc_frontend_connect function from the
@@ -670,14 +678,6 @@ ipc_frontend_dbus_connect (IpcFrontendDbus *self,
     g_return_if_fail (IS_IPC_FRONTEND_DBUS (self));
 
     frontend->init_mutex = init_mutex;
-    self->dbus_name_owner_id = g_bus_own_name (self->bus_type,
-                                               self->bus_name,
-                                               G_BUS_NAME_OWNER_FLAGS_NONE,
-                                               on_bus_acquired,
-                                               on_name_acquired,
-                                               on_name_lost,
-                                               self,
-                                               NULL);
     g_dbus_proxy_new_for_bus (self->bus_type,
                               G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                               NULL,


### PR DESCRIPTION
When started via dbus activation, it can happen that a request is
recieved before dbus_daemon_proxy is set by on_get_dbus_daemon_proxy. In
that case, get_pid_from_dbus_invocation has no proxy and fails.

That results in an error on the client side:
```
  ** (process:521): WARNING **: 00:02:34.701: Failed to create connection
  with service: GDBus.Error:com.intel.tss2.Tabrmd.Error.Internal: Failed
  to get client PID
  ERROR: tcti init allocation routine failed for library: "tabrmd"
  options: "(null)"
  ERROR: Could not load tcti, got: "tabrmd"
```

Fix this by registering the name only when the proxy is initialized
already.

I've tested this with a loop that starts tpm2-abrmd and uses tpm2_getrandom to start it via bus-activation.