### PR TITLE
configure.ac: tweaks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,11 +110,10 @@ AC_SUBST([dbuspolicydir], [$with_dbuspolicydir])
 #
 AC_ARG_ENABLE([test-hwtpm],
               [AS_HELP_STRING([--enable-test-hwtpm],
-                  [enable the integration test on a real tpm hardware (default is no)])],
-              [enable_hwtpm=$enableval
-               enable_integration=$enableval],
-              [enable_hwtpm=no])
-AM_CONDITIONAL([HWTPM], [test "x$enable_hwtpm" != xno])
+                  [enable the integration test on a real tpm hardware])],
+              [enable_integration=$enableval],
+              [enable_test_hwtpm=no])
+AM_CONDITIONAL([HWTPM], [test "x$enable_test_hwtpm" != xno])
 #
 # enable integration tests and check for simulator binary
 #
@@ -122,7 +121,7 @@ AC_ARG_ENABLE([integration],
     [AS_HELP_STRING([--enable-integration],
         [build and execute integration tests])],,
     [enable_integration=no])
-AS_IF([test \( "x$enable_integration" = "xyes" \) -a \( "x$enable_hwtpm" = "xno" \)],
+AS_IF([test \( "x$enable_integration" = "xyes" \) -a \( "x$enable_test_hwtpm" = "xno" \)],
     [AC_CHECK_PROG([tpm_server], [tpm_server], [yes], [no])
      AS_IF([test "x$tpm_server" != "xyes"],
          [AC_MSG_ERROR([Integration tests enabled but tpm_server not found, try setting PATH])])

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
 AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])
 AC_ARG_ENABLE([unit],
               [AS_HELP_STRING([--enable-unit],
-                   [build cmocka unit tests (default is no)])],,
+                   [build cmocka unit tests])],,
               [enable_unit=no])
 AS_IF([test "x$enable_unit" != xno],
       [PKG_CHECK_MODULES([CMOCKA],
@@ -120,7 +120,7 @@ AM_CONDITIONAL([HWTPM], [test "x$enable_hwtpm" != xno])
 #
 AC_ARG_ENABLE([integration],
     [AS_HELP_STRING([--enable-integration],
-        [build and execute integration tests (default is no)])],,
+        [build and execute integration tests])],,
     [enable_integration=no])
 AS_IF([test \( "x$enable_integration" = "xyes" \) -a \( "x$enable_hwtpm" = "xno" \)],
     [AC_CHECK_PROG([tpm_server], [tpm_server], [yes], [no])


### PR DESCRIPTION
* don’t print after ./configure --help » --enable-X that feature X is disabled by default as this is implicit.
* AC_ARG_ENABLE: handle test-hwtpm the Autoconf way