### PR TITLE
deheader: remove double #include’d headers

### DIFF
--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -18,7 +18,6 @@
 #include "access-broker.h"
 #include "connection.h"
 #include "connection-manager.h"
-#include "tabrmd.h"
 #include "logging.h"
 #include "thread.h"
 #include "command-source.h"

--- a/test/tcti-util_unit.c
+++ b/test/tcti-util_unit.c
@@ -10,7 +10,6 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "util.h"


### PR DESCRIPTION
Found by http://www.catb.org/~esr/deheader/ .