### PR TITLE
tcti-factory: Add check for null after TCTI initialization.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -435,7 +435,7 @@ test_tcti_unit_LDADD    = $(CMOCKA_LIBS) $(GLIB_LIBS) $(GOBJECT_LIBS) $(libutil)
 test_tcti_unit_SOURCES  = test/tcti_unit.c
 
 test_tcti_factory_unit_CFLAGS   = $(UNIT_AM_CFLAGS)
-test_tcti_factory_unit_LDADD    = $(CMOCKA_LIBS) $(GLIB_LIBS) $(GOBJECT_LIBS) $(libutil)
+test_tcti_factory_unit_LDADD    = $(CMOCKA_LIBS) $(GLIB_LIBS) $(GOBJECT_LIBS) $(libutil) $(libtest)
 test_tcti_factory_unit_LDFLAGS = -Wl,--wrap=tcti_util_discover_info,--wrap=tcti_util_dynamic_init,--wrap=dlclose
 test_tcti_factory_unit_SOURCES  = test/tcti-factory_unit.c
 

--- a/src/tcti-factory.c
+++ b/src/tcti-factory.c
@@ -135,7 +135,7 @@ tcti_factory_create (TctiFactory *self)
     TSS2_RC rc = TSS2_RC_SUCCESS;
     void *dl_handle = NULL;
     const TSS2_TCTI_INFO *info;
-    TSS2_TCTI_CONTEXT *ctx;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
 
     g_debug ("%s: TctiFactory %p with TCTI '%s' and conf '%s'",
              __func__, objid (self), self->name, self->conf);
@@ -150,7 +150,7 @@ tcti_factory_create (TctiFactory *self)
     g_debug ("%s: tcti_util_dynamic_init", __func__);
     rc = tcti_util_dynamic_init (info, self->conf, &ctx);
     g_debug ("%s: after tcti_util_dynamic_init", __func__);
-    if (rc != TSS2_RC_SUCCESS) {
+    if (rc != TSS2_RC_SUCCESS || ctx == NULL) {
         g_info ("%s: failed to initialize TCTI, RC: 0x%" PRIx32,
                  __func__, rc);
 #if !defined (DISABLE_DLCLOSE)

--- a/test/tcti-factory_unit.c
+++ b/test/tcti-factory_unit.c
@@ -7,6 +7,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
+#include "tcti-mock.h"
 #include "tcti-factory.h"
 #include "util.h"
 
@@ -111,11 +112,13 @@ tcti_factory_create_test (void **state)
     TctiFactory *factory = TCTI_FACTORY (*state);
     Tcti *tcti = NULL;
     TSS2_TCTI_INFO info = { 0 };
+    TSS2_TCTI_CONTEXT *tcti_ctx = NULL;
 
+    tcti_ctx = tcti_mock_init_full ();
     will_return (__wrap_tcti_util_discover_info, &info);
     will_return (__wrap_tcti_util_discover_info, TCTI_UTIL_UNIT_HANDLE);
     will_return (__wrap_tcti_util_discover_info, TSS2_RC_SUCCESS);
-    will_return (__wrap_tcti_util_dynamic_init, NULL);
+    will_return (__wrap_tcti_util_dynamic_init, tcti_ctx);
     will_return (__wrap_tcti_util_dynamic_init, TSS2_RC_SUCCESS);
 #if !defined (DISABLE_DLCLOSE)
     will_return (__wrap_dlclose, 0);


### PR DESCRIPTION
The code checks the return value and assumes that the context has been
set to a non-NULL value if the response code indicates success. Most
static analysis tools don't look down into the 'tcti_util_dynamic_init'
function to see that this is safe however. Adding an explicit check
comes at nearly no cost and makes the code clear. Some cleanup was
required in the unit test that relied on the old behavior as well.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>