### PR TITLE
test: remove start-auth-session.int.c from the XFAIL list

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -71,8 +71,7 @@ TESTS_INTEGRATION_NOHW = test/integration/tcti-connect-multiple.int
 # empty init for these since they're manipulated by conditionals
 TESTS =
 noinst_LTLIBRARIES =
-XFAIL_TESTS = \
-    test/integration/start-auth-session.int
+XFAIL_TESTS =
 TEST_EXTENSIONS = .int
 AM_TESTS_ENVIRONMENT = \
     TEST_FUNC_LIB=$(srcdir)/scripts/int-test-funcs.sh \

--- a/test/integration/start-auth-session.int.c
+++ b/test/integration/start-auth-session.int.c
@@ -148,9 +148,9 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     }
     g_info ("StartAuthSession for TPM_SE_POLICY success! Session handle: "
             "0x%08" PRIx32, session_handle);
-    handles_count (sapi_context, TPM2_LOADED_SESSION_FIRST, &count);
-    g_assert (count == 1);
     handles_count (sapi_context, TPM2_ACTIVE_SESSION_FIRST, &count);
+    g_assert (count == 1);
+    handles_count (sapi_context, TPM2_LOADED_SESSION_FIRST, &count);
     g_assert (count == 0);
     dump_loaded_active_handles (sapi_context);
 
@@ -164,10 +164,10 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
             session_handle);
     prettyprint_context (&context);
     dump_loaded_active_handles (sapi_context);
-    handles_count (sapi_context, TPM2_LOADED_SESSION_FIRST, &count);
-    g_assert (count == 0);
     handles_count (sapi_context, TPM2_ACTIVE_SESSION_FIRST, &count);
     g_assert (count == 1);
+    handles_count (sapi_context, TPM2_LOADED_SESSION_FIRST, &count);
+    g_assert (count == 0);
 
     /* load context */
     g_info ("Loading context for session: 0x%" PRIxHANDLE, session_handle);
@@ -183,9 +183,9 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
         g_info ("session_handle != session_handle_load");
     }
     dump_loaded_active_handles (sapi_context);
-    handles_count (sapi_context, TPM2_LOADED_SESSION_FIRST, &count);
-    g_assert (count == 1);
     handles_count (sapi_context, TPM2_ACTIVE_SESSION_FIRST, &count);
+    g_assert (count == 1);
+    handles_count (sapi_context, TPM2_LOADED_SESSION_FIRST, &count);
     g_assert (count == 0);
 
     g_info ("Flushing context for session: 0x%" PRIxHANDLE, session_handle);
@@ -196,9 +196,9 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     g_info ("Flushed context for session handle: 0x%" PRIxHANDLE " success!",
             session_handle);
     dump_loaded_active_handles (sapi_context);
-    handles_count (sapi_context, TPM2_LOADED_SESSION_FIRST, &count);
-    g_assert (count == 0);
     handles_count (sapi_context, TPM2_ACTIVE_SESSION_FIRST, &count);
+    g_assert (count == 0);
+    handles_count (sapi_context, TPM2_LOADED_SESSION_FIRST, &count);
     g_assert (count == 0);
 
     return 0;


### PR DESCRIPTION
The test creates a single POLICY session and then calls Tss2_Sys_GetCapability()
to report on the number of session handles.  The test failure was caused by
using TPM2_ACTIVE_SESSION_FIRST instead of TPM2_LOADED_SESSION_FIRST and
vice-versa.  LOADED_SESSION_FIRST is defined as HMAC_SESSION_FIRST and
ACTIVE_SESSION_FIRST is defined as POLICY_SESSION_FIRST.  During the test we
should expect 0 of the former and 1 of the latter.

Signed-off-by: Jeffrey Ferreira <jeffpferreira@gmail.com>