### PR TITLE
Use AC_CONFIG_FILES for variable substitution, improve pkg-config file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -125,9 +125,6 @@ EXTRA_DIST = \
     man/tss2-tcti-tabrmd.7.in \
     man/tpm2-abrmd.8.in \
     dist/tpm2-abrmd.conf \
-    dist/tpm2-abrmd.preset.in \
-    dist/tss2-tcti-tabrmd.pc.in \
-    dist/tpm2-abrmd.service.in \
     dist/com.intel.tss2.Tabrmd.service \
     scripts/int-test-funcs.sh \
     scripts/int-test-setup.sh \
@@ -147,12 +144,14 @@ CLEANFILES = \
     $(man_MANS) \
     src/tabrmd-generated.c \
     src/tabrmd-generated.h \
-    $(pkgconfig_DATA) \
-    $(systemdpreset_DATA) \
-    $(systemdsystemunit_DATA) \
     test/integration/*.log \
     _tabrmd.log
-DISTCLEANFILES = core default.profraw
+DISTCLEANFILES = \
+    core \
+    default.profraw \
+    $(pkgconfig_DATA) \
+    $(systemdpreset_DATA) \
+    $(systemdsystemunit_DATA)
 
 BUILT_SOURCES = src/tabrmd-generated.h src/tabrmd-generated.c
 
@@ -307,20 +306,6 @@ endef # man_tcti_prefix
 	$(AM_V_GEN)$(call make_parent_dir,$@) && \
 	$(GDBUS_CODEGEN) --interface-prefix=com.intel.tss2. \
 	    --generate-c-code=src/tabrmd-generated $^
-
-%.preset : %.preset.in
-	$(AM_V_GEN)$(call make_parent_dir,$@) && \
-	sed -e "s,[@]SYSTEMD_PRESET_DEFAULT[@],$(SYSTEMD_PRESET_DEFAULT),g;" $^ > $@
-
-%.service : %.service.in
-	$(AM_V_GEN)$(call make_parent_dir,$@) && \
-	sed -e "s,[@]SBINDIR[@],$(sbindir),g; \
-	        s,[@]sysconfdir[@],$(sysconfdir),g;" $^ > $@
-
-%.pc : %.pc.in
-	$(AM_V_GEN)$(call make_parent_dir,$@) && \
-	sed -e "s,[@]VERSION[@],$(PACKAGE_VERSION),g; \
-                s,[@]includedir[@],$(includedir),g;" $^ > $@
 
 define make_parent_dir
     if [ ! -d $(dir $1) ]; then mkdir -p $(dir $1); fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -155,7 +155,6 @@ DISTCLEANFILES = \
 
 BUILT_SOURCES = src/tabrmd-generated.h src/tabrmd-generated.c
 
-pkgconfigdir     = $(libdir)/pkgconfig
 pkgconfig_DATA   = dist/tss2-tcti-tabrmd.pc
 dbuspolicy_DATA  = dist/tpm2-abrmd.conf
 if HAVE_SYSTEMD

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,11 @@ LT_INIT()
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 # enable "silent-rules" option by default
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
-AC_CONFIG_FILES([Makefile])
+
+AX_RECURSIVE_EVAL([$sbindir], [SBINDIR])
+AC_SUBST([SBINDIR])
+
+AC_CONFIG_FILES([Makefile dist/tss2-tcti-tabrmd.pc dist/tpm2-abrmd.service dist/tpm2-abrmd.preset])
 
 # propagate configure arguments to distcheck
 AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 AC_PROG_LN_S
 LT_INIT()
+PKG_INSTALLDIR()
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 # enable "silent-rules" option by default
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])

--- a/dist/tss2-tcti-tabrmd.pc.in
+++ b/dist/tss2-tcti-tabrmd.pc.in
@@ -8,4 +8,5 @@ Description: TCTI library for communicating with the TPM2 access broker / resour
 URL: https://github.com/tpm2-software/tpm2-abrmd
 Version: @VERSION@
 Requires: tss2-mu glib-2.0 gio-2.0
-Libs: -ltss2-tcti-tabrmd
+Cflags: -I${includedir}
+Libs: -L${libdir} -ltss2-tcti-tabrmd

--- a/dist/tss2-tcti-tabrmd.pc.in
+++ b/dist/tss2-tcti-tabrmd.pc.in
@@ -1,3 +1,8 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
 Name: tss2-tcti-tabrmd
 Description: TCTI library for communicating with the TPM2 access broker / resource manager daemon (tabrmd).
 URL: https://github.com/tpm2-software/tpm2-abrmd


### PR DESCRIPTION
Apply the changes made upstream in https://github.com/tpm2-software/tpm2-tss/pull/1372 and https://github.com/tpm2-software/tpm2-tss/pull/1384 to tpm2-abrmd:
- Use `AC_CONFIG_FILES` instead of `sed` for variable substitutions.
- Define variables for `libdir` and `includedir` in the pkg-config file and use `-I` and `-L`. This is standard practice, see the [example pkg-config file](https://people.freedesktop.org/~dbn/pkg-config-guide.html#using).
- Use `PKG_INSTALLDIR` to determine the pkg-config directory, which allows changing it with `./configure --with-pkgconfigdir`.