### PR TITLE
Add ccache to speed up travis runs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: c
 dist: xenial
 
+cache: ccache
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
see [https://github.com/tpm2-software/tpm2-tss/pull/1403](https://github.com/tpm2-software/tpm2-tss/pull/1403)

Signed-off-by: Dominic Grauvogl <dominicmanuel.grauvogl@infineon.com>