### PR TITLE
Fix bad SPDX-License-Identifier.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2-Clause
 # we have BUILT_SOURCES so builddir must be in VPATH
 VPATH = $(srcdir) $(builddir)
 ACLOCAL_AMFLAGS = -I m4 --install

--- a/bootstrap
+++ b/bootstrap
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SPDX-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2-Clause
 
 git describe --tags --always --dirty > VERSION
 autoreconf --install --sym

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2-Clause
 AC_INIT([tpm2-abrmd],
         [m4_esyscmd_s([cat ./VERSION])],
         [https://github.com/tpm2-software/tpm2-abrmd/issues],

--- a/coverity/coverity-model.c
+++ b/coverity/coverity-model.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/scripts/int-test-funcs.sh
+++ b/scripts/int-test-funcs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2-Clause
 #
 # Copyright (c) 2017, Intel Corporation
 # All rights reserved.

--- a/scripts/int-test-setup.sh
+++ b/scripts/int-test-setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2-Clause
 #
 # Copyright (c) 2017, Intel Corporation
 # All rights reserved.

--- a/src/access-broker.c
+++ b/src/access-broker.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/access-broker.h
+++ b/src/access-broker.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/command-attrs.c
+++ b/src/command-attrs.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/command-attrs.h
+++ b/src/command-attrs.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/command-source.c
+++ b/src/command-source.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/command-source.h
+++ b/src/command-source.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/connection-manager.c
+++ b/src/connection-manager.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/connection-manager.h
+++ b/src/connection-manager.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/connection.c
+++ b/src/connection.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/connection.h
+++ b/src/connection.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/control-message.c
+++ b/src/control-message.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/control-message.h
+++ b/src/control-message.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/handle-map-entry.c
+++ b/src/handle-map-entry.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/handle-map-entry.h
+++ b/src/handle-map-entry.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/handle-map.c
+++ b/src/handle-map.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/handle-map.h
+++ b/src/handle-map.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/include/tss2-tcti-tabrmd.h
+++ b/src/include/tss2-tcti-tabrmd.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/ipc-frontend-dbus.c
+++ b/src/ipc-frontend-dbus.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/ipc-frontend-dbus.h
+++ b/src/ipc-frontend-dbus.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/ipc-frontend.c
+++ b/src/ipc-frontend.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/ipc-frontend.h
+++ b/src/ipc-frontend.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/logging.c
+++ b/src/logging.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/message-queue.c
+++ b/src/message-queue.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/message-queue.h
+++ b/src/message-queue.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/random.c
+++ b/src/random.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/random.h
+++ b/src/random.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/resource-manager-session.c
+++ b/src/resource-manager-session.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 #include <glib.h>
 #include <inttypes.h>
 

--- a/src/resource-manager-session.h
+++ b/src/resource-manager-session.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 #ifndef RESOURCE_MANAGER_SESSION_H
 #define RESOURCE_MANAGER_SESSION_H
 

--- a/src/resource-manager.c
+++ b/src/resource-manager.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/resource-manager.h
+++ b/src/resource-manager.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/response-sink.c
+++ b/src/response-sink.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/response-sink.h
+++ b/src/response-sink.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/session-entry-state-enum.c
+++ b/src/session-entry-state-enum.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/session-entry-state-enum.h
+++ b/src/session-entry-state-enum.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/session-entry.c
+++ b/src/session-entry.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/session-entry.h
+++ b/src/session-entry.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/session-list.c
+++ b/src/session-list.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/session-list.h
+++ b/src/session-list.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/sink-interface.c
+++ b/src/sink-interface.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/sink-interface.h
+++ b/src/sink-interface.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/source-interface.c
+++ b/src/source-interface.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/source-interface.h
+++ b/src/source-interface.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/tabrmd-defaults.h
+++ b/src/tabrmd-defaults.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: BSD-2
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2019, Intel Corporation
  */
 #ifndef TABRMD_DEFAULTS_H

--- a/src/tabrmd-error.c
+++ b/src/tabrmd-error.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 #include <gio/gio.h>
 #include <glib.h>
 #include "tabrmd.h"

--- a/src/tabrmd-options.c
+++ b/src/tabrmd-options.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: BSD-2
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2019, Intel Corporation
  */
 #include <glib.h>

--- a/src/tabrmd-options.h
+++ b/src/tabrmd-options.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: BSD-2
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2019, Intel Corporation
  */
 #ifndef TABRMD_OPTIONS_H

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tabrmd.h
+++ b/src/tabrmd.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tcti-factory.c
+++ b/src/tcti-factory.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 #include <dlfcn.h>
 #include <inttypes.h>
 

--- a/src/tcti-factory.h
+++ b/src/tcti-factory.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 #ifndef TCTI_FACTORY_H
 #define TCTI_FACTORY_H
 

--- a/src/tcti-tabrmd-priv.h
+++ b/src/tcti-tabrmd-priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tcti-util.c
+++ b/src/tcti-util.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.

--- a/src/tcti-util.h
+++ b/src/tcti-util.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.

--- a/src/tcti.c
+++ b/src/tcti.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tcti.h
+++ b/src/tcti.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/thread.c
+++ b/src/thread.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/thread.h
+++ b/src/thread.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/tpm2-command.c
+++ b/src/tpm2-command.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/tpm2-command.h
+++ b/src/tpm2-command.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tpm2-header.c
+++ b/src/tpm2-header.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tpm2-header.h
+++ b/src/tpm2-header.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tpm2-response.c
+++ b/src/tpm2-response.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/tpm2-response.h
+++ b/src/tpm2-response.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/src/util.c
+++ b/src/util.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/src/util.h
+++ b/src/util.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/access-broker_unit.c
+++ b/test/access-broker_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/command-attrs_unit.c
+++ b/test/command-attrs_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/command-source_unit.c
+++ b/test/command-source_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/connection-manager_unit.c
+++ b/test/connection-manager_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/connection_unit.c
+++ b/test/connection_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/handle-map-entry_unit.c
+++ b/test/handle-map-entry_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/handle-map_unit.c
+++ b/test/handle-map_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/auth-session-max.int.c
+++ b/test/integration/auth-session-max.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/auth-session-start-flush.int.c
+++ b/test/integration/auth-session-start-flush.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/auth-session-start-save-load.int.c
+++ b/test/integration/auth-session-start-save-load.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/auth-session-start-save.int.c
+++ b/test/integration/auth-session-start-save.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/common.c
+++ b/test/integration/common.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/common.h
+++ b/test/integration/common.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/context-util.h
+++ b/test/integration/context-util.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/get-capability-handles-transient.int.c
+++ b/test/integration/get-capability-handles-transient.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/hash-sequence.int.c
+++ b/test/integration/hash-sequence.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/main.c
+++ b/test/integration/main.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/manage-transient-keys.int.c
+++ b/test/integration/manage-transient-keys.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/integration/max-transient-upperbound.int.c
+++ b/test/integration/max-transient-upperbound.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/not-enough-handles-for-command.int.c
+++ b/test/integration/not-enough-handles-for-command.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/password-authorization.int.c
+++ b/test/integration/password-authorization.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/session-gap.int.c
+++ b/test/integration/session-gap.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 #include <inttypes.h>
 #include <glib.h>
 #include <string.h>

--- a/test/integration/session-load-from-closed-connection.int.c
+++ b/test/integration/session-load-from-closed-connection.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/session-load-from-closed-connections-lru.int.c
+++ b/test/integration/session-load-from-closed-connections-lru.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/session-load-from-open-connection.int.c
+++ b/test/integration/session-load-from-open-connection.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/start-auth-session.int.c
+++ b/test/integration/start-auth-session.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/tcti-cancel.int.c
+++ b/test/integration/tcti-cancel.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/integration/tcti-connect-multiple.int.c
+++ b/test/integration/tcti-connect-multiple.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/tcti-connections-max.int.c
+++ b/test/integration/tcti-connections-max.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/tcti-double-finalize.int.c
+++ b/test/integration/tcti-double-finalize.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/tcti-set-locality.int.c
+++ b/test/integration/tcti-set-locality.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/integration/test-options.c
+++ b/test/integration/test-options.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/test-options.h
+++ b/test/integration/test-options.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/test.h
+++ b/test/integration/test.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/tpm2-command-flush-no-handle.int.c
+++ b/test/integration/tpm2-command-flush-no-handle.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/integration/tpm2-struct-init.h
+++ b/test/integration/tpm2-struct-init.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/integration/util-buf-max-upper-bound.int.c
+++ b/test/integration/util-buf-max-upper-bound.int.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/ipc-frontend-dbus_unit.c
+++ b/test/ipc-frontend-dbus_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/ipc-frontend_unit.c
+++ b/test/ipc-frontend_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/logging_unit.c
+++ b/test/logging_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/message-queue_unit.c
+++ b/test/message-queue_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/mock-io-stream.c
+++ b/test/mock-io-stream.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.

--- a/test/mock-io-stream.h
+++ b/test/mock-io-stream.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2018, Intel Corporation
  * All rights reserved.

--- a/test/msg_unit.c
+++ b/test/msg_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/random_unit.c
+++ b/test/random_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/response-sink_unit.c
+++ b/test/response-sink_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/session-entry_unit.c
+++ b/test/session-entry_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/session-list_unit.c
+++ b/test/session-list_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/tab_unit.c
+++ b/test/tab_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/tabrmd-options_unit.c
+++ b/test/tabrmd-options_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/tcti-factory_unit.c
+++ b/test/tcti-factory_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/test/tcti-mock.c
+++ b/test/tcti-mock.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdlib.h>

--- a/test/tcti-mock.h
+++ b/test/tcti-mock.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 #ifndef TCTI_MOCK_H
 #define TCTI_MOCK_H
 

--- a/test/tcti-util_unit.c
+++ b/test/tcti-util_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/tcti_unit.c
+++ b/test/tcti_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdlib.h>

--- a/test/test-skeleton_unit.c
+++ b/test/test-skeleton_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/thread_unit.c
+++ b/test/thread_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/tpm2-command_unit.c
+++ b/test/tpm2-command_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/tpm2-response_unit.c
+++ b/test/tpm2-response_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.

--- a/test/tss2-tcti-tabrmd_unit.c
+++ b/test/tss2-tcti-tabrmd_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.

--- a/test/util_unit.c
+++ b/test/util_unit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-2 */
+/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2017 - 2018, Intel Corporation
  * All rights reserved.


### PR DESCRIPTION
The current string was taken from the work done in the tpm2-tss repo. It
was wrong unfortunately.

This resolves #624 

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>