### PR TITLE
tabrmd-options: Fix bug introduced in c5e66b78de.

### DIFF
--- a/src/tabrmd-options.c
+++ b/src/tabrmd-options.c
@@ -65,17 +65,17 @@ tcti_conf_parse (gchar *combined_conf,
 
     g_debug ("%s", __func__);
     if (tcti_filename == NULL || tcti_conf == NULL) {
-        g_info ("%s: tcti_filename and tcti_conf out params may not be NULL",
-                __func__);
+        g_critical ("%s: tcti_filename and tcti_conf out params may not be NULL",
+                    __func__);
         return FALSE;
     }
     if (combined_conf == NULL) {
         g_debug ("%s: combined conf is null", __func__);
-        return FALSE;
+        return TRUE;
     }
     if (strlen (combined_conf) == 0) {
         g_debug ("%s: combined conf is the empty string", __func__);
-        return FALSE;
+        return TRUE;
     }
 
     split = strchr (combined_conf, ':');
@@ -160,6 +160,7 @@ parse_opts (gint argc,
         g_critical ("Failed to parse options: %s", err->message);
         return FALSE;
     }
+    g_option_context_free (ctx);
     /* select the bus type, default to G_BUS_TYPE_SESSION */
     options->bus = session_bus ? G_BUS_TYPE_SESSION : G_BUS_TYPE_SYSTEM;
     if (set_logger (logger_name) == -1) {
@@ -187,12 +188,7 @@ parse_opts (gint argc,
                     TABRMD_TRANSIENT_MAX);
         return FALSE;
     }
-    if (!tcti_conf_parse (tcti_optconf,
-                          &options->tcti_filename,
-                          &options->tcti_conf)) {
-        g_critical ("bad tcti conf string");
-        return FALSE;
-    }
-    g_option_context_free (ctx);
-    return TRUE;
+    return tcti_conf_parse (tcti_optconf,
+                            &options->tcti_filename,
+                            &options->tcti_conf);
 }

--- a/test/tabrmd-options_unit.c
+++ b/test/tabrmd-options_unit.c
@@ -26,7 +26,7 @@ tcti_conf_parse_test_null_conf (void **state)
     UNUSED_PARAM (state);
     gchar *tcti_filename, *tcti_conf;
 
-    assert_false (tcti_conf_parse (NULL, &tcti_filename, &tcti_conf));
+    assert_true (tcti_conf_parse (NULL, &tcti_filename, &tcti_conf));
 }
 static void
 tcti_conf_parse_test_zero_conf (void **state)
@@ -34,7 +34,7 @@ tcti_conf_parse_test_zero_conf (void **state)
     UNUSED_PARAM (state);
     gchar *tcti_filename, *tcti_conf;
 
-    assert_false (tcti_conf_parse ("", &tcti_filename, &tcti_conf));
+    assert_true (tcti_conf_parse ("", &tcti_filename, &tcti_conf));
 }
 static void
 tcti_conf_parse_test_name_only (void **state)
@@ -199,24 +199,6 @@ tcti_conf_parse_opts_max_transient_fail (void **state)
     will_return (__wrap_set_logger, 0);
     assert_false (parse_opts (argc, argv, &options));
 }
-static void
-tcti_conf_parse_opts_tcti_conf_fail (void **state)
-{
-    UNUSED_PARAM (state);
-    tabrmd_options_t options = TABRMD_OPTIONS_INIT_DEFAULT;
-    GOptionContext *ctx = NULL;
-    int argc = 0;
-    char **argv = NULL;
-    GError error = { .message = "foo", };
-
-    options.tcti_filename = NULL;
-    will_return (__wrap_g_option_context_new, ctx);
-    will_return (__wrap_g_option_context_add_main_entries, "foo");
-    will_return (__wrap_g_option_context_parse, &error);
-    will_return (__wrap_g_option_context_parse, TRUE);
-    will_return (__wrap_set_logger, 0);
-    assert_false (parse_opts (argc, argv, &options));
-}
 void
 __wrap_g_option_context_free (GOptionContext *context)
 {
@@ -258,7 +240,6 @@ main (void)
         cmocka_unit_test (tcti_conf_parse_opts_max_connections_fail),
         cmocka_unit_test (tcti_conf_parse_opts_max_sessions_fail),
         cmocka_unit_test (tcti_conf_parse_opts_max_transient_fail),
-        cmocka_unit_test (tcti_conf_parse_opts_tcti_conf_fail),
         cmocka_unit_test (tcti_conf_parse_opts_success),
     };
     return cmocka_run_group_tests (tests, NULL, NULL);


### PR DESCRIPTION
The comment above this function clearly states the reason for these
return values. This was however missed in this refactoring. This fix
includes a small change to free the GOptionContext as early as possible.
This allows us to eliminate the final conditional returning the status
from the last function call directly.

This allows us to eliminate one of the unit tests without affecting the
coverage metrics.

This resolves #625 

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>