### PR TITLE
thread: test if thread handle is valid before joining

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -51,6 +51,11 @@ thread_cancel (Thread *self)
 gint
 thread_join (Thread *self)
 {
+    if (self->thread_id == 0) {
+        g_warning ("thread not running");
+        return -1;
+    }
+
     gint ret = pthread_join (self->thread_id, NULL);
     self->thread_id = 0;
     return ret;


### PR DESCRIPTION
`pthread_join` can crash if called with an invalid thread handle, so we test the handle as in `thread_start` and `thread_cancel`. This fixes the test failure reported in #627.