### PR TITLE
pkg-config: sort out dependencies

### DIFF
--- a/dist/tss2-tcti-tabrmd.pc.in
+++ b/dist/tss2-tcti-tabrmd.pc.in
@@ -7,6 +7,6 @@ Name: tss2-tcti-tabrmd
 Description: TCTI library for communicating with the TPM2 access broker / resource manager daemon (tabrmd).
 URL: https://github.com/tpm2-software/tpm2-abrmd
 Version: @VERSION@
-Requires: tss2-mu glib-2.0 gio-2.0
+Requires.private: tss2-mu glib-2.0 gio-2.0
 Cflags: -I${includedir}
 Libs: -L${libdir} -ltss2-tcti-tabrmd

--- a/dist/tss2-tcti-tabrmd.pc.in
+++ b/dist/tss2-tcti-tabrmd.pc.in
@@ -7,6 +7,7 @@ Name: tss2-tcti-tabrmd
 Description: TCTI library for communicating with the TPM2 access broker / resource manager daemon (tabrmd).
 URL: https://github.com/tpm2-software/tpm2-abrmd
 Version: @VERSION@
-Requires.private: tss2-mu glib-2.0 gio-2.0
-Cflags: -I${includedir}
+Requires.private: tss2-sys tss2-mu glib-2.0 gio-2.0
+Cflags: -I${includedir} @PTHREAD_CFLAGS@
 Libs: -L${libdir} -ltss2-tcti-tabrmd
+Libs.private: @PTHREAD_LIBS@


### PR DESCRIPTION
As in https://github.com/tpm2-software/tpm2-tss/pull/1417, move the dependencies from `Requires` to `Requires.private` and add further necessary dependencies according to the Makefile.

Like https://github.com/tpm2-software/tpm2-tss/pull/1417, the first commit breaks the public API. However the impact is much smaller than for tpm2-tss since libtss2-tabrmd-tcti is usually not linked, but loaded with `dlopen()`. I found no projects using the pkg-config file within the tpm2-software organisation, so nothing will break here.

The second commit is completely backwards-compatible since it only adds new necessary dependencies. It is pending #630 to actually remove the uncessary libdbus-1 dependency.