### PR TITLE
build: Ignore m4 file imported by autoconf *_EXTENSIONS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ m4/ltoptions.m4
 m4/ltsugar.m4
 m4/ltversion.m4
 m4/ax_*.m4
+m4/extensions.m4
 m4/pkg.m4
 man/man*/
 missing


### PR DESCRIPTION
Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>