### PR TITLE
build: Remove unnecessary pthread lib from TCTI dependencies.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -279,8 +279,8 @@ test_integration_libtest_la_SOURCES = \
     test/tcti-mock.c \
     test/tcti-mock.h
 
-src_libtss2_tcti_tabrmd_la_LIBADD   = $(GIO_LIBS) $(GLIB_LIBS) \
-    $(PTHREAD_LIBS) $(libutil) $(TSS2_SYS_LIBS)
+src_libtss2_tcti_tabrmd_la_LIBADD = $(GIO_LIBS) $(GLIB_LIBS) $(TSS2_MU_LIBS) \
+    $(libutil)
 src_libtss2_tcti_tabrmd_la_LDFLAGS = -fPIC -Wl,--no-undefined -Wl,-z,nodelete -Wl,--version-script=$(srcdir)/src/tcti-tabrmd.map
 src_libtss2_tcti_tabrmd_la_SOURCES = src/tcti-tabrmd.c src/tcti-tabrmd-priv.h $(srcdir)/src/tcti-tabrmd.map
 

--- a/dist/tss2-tcti-tabrmd.pc.in
+++ b/dist/tss2-tcti-tabrmd.pc.in
@@ -8,6 +8,5 @@ Description: TCTI library for communicating with the TPM2 access broker / resour
 URL: https://github.com/tpm2-software/tpm2-abrmd
 Version: @VERSION@
 Requires.private: tss2-sys tss2-mu glib-2.0 gio-2.0
-Cflags: -I${includedir} @PTHREAD_CFLAGS@
+Cflags: -I${includedir}
 Libs: -L${libdir} -ltss2-tcti-tabrmd
-Libs.private: @PTHREAD_LIBS@


### PR DESCRIPTION
This isn't explicitly required. We still end up linking against
libpthread on account of GIO_LIBS but the TCTI does not use pthreads
directly.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>

This is resolves #633