### PR TITLE
util: replace xor address obfuscation / objid with truncated sha256

### DIFF
--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -36,7 +36,6 @@ main (int argc, char *argv[])
     GThread *init_thread;
     gint init_ret;
 
-    util_init ();
     g_info ("tabrmd startup");
     if (!parse_opts (argc, argv, &gmain_data.options)) {
         return 1;

--- a/src/util.h
+++ b/src/util.h
@@ -92,7 +92,6 @@ void        g_debug_tpma_cc                 (TPMA_CC           tpma_cc);
 TSS2_RC     parse_key_value_string (char *kv_str,
                                     KeyValueFunc callback,
                                     gpointer user_data);
-void util_init (void);
 void* objid (const void* ptr);
 
 #endif /* UTIL_H */

--- a/test/access-broker_unit.c
+++ b/test/access-broker_unit.c
@@ -342,7 +342,6 @@ access_broker_send_command_success (void **state)
 int
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (access_broker_type_test,
                                          access_broker_setup,

--- a/test/command-attrs_unit.c
+++ b/test/command-attrs_unit.c
@@ -268,7 +268,6 @@ command_attrs_from_cc_fail_test (void **state)
 gint
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (command_attrs_type_test,
                                          command_attrs_setup,

--- a/test/command-source_unit.c
+++ b/test/command-source_unit.c
@@ -344,7 +344,6 @@ command_source_on_io_ready_eof_test (void **state)
 int
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (command_source_allocate_test,
                                          command_source_allocate_setup,

--- a/test/connection-manager_unit.c
+++ b/test/connection-manager_unit.c
@@ -138,7 +138,6 @@ connection_manager_remove_test (void **state)
 int
 main(void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (connection_manager_allocate_test),
         cmocka_unit_test_setup_teardown (connection_manager_insert_test,

--- a/test/connection_unit.c
+++ b/test/connection_unit.c
@@ -167,7 +167,6 @@ connection_server_to_client_test (void **state)
 int
 main(void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (connection_allocate_test),
         cmocka_unit_test_setup_teardown (connection_key_socket_test,

--- a/test/handle-map-entry_unit.c
+++ b/test/handle-map-entry_unit.c
@@ -89,7 +89,6 @@ handle_map_entry_get_vhandle_test (void **state)
 gint
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (handle_map_entry_type_test,
                                          handle_map_entry_setup,

--- a/test/handle-map_unit.c
+++ b/test/handle-map_unit.c
@@ -138,7 +138,6 @@ handle_map_next_vhandle_test (void **state)
 int
 main(void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (handle_map_type_test,
                                          handle_map_setup_base,

--- a/test/integration/main.c
+++ b/test/integration/main.c
@@ -28,7 +28,6 @@ main ()
     int ret;
     test_opts_t opts = TEST_OPTS_DEFAULT_INIT;
 
-    util_init ();
     get_test_opts_from_env (&opts);
     if (sanity_check_test_opts (&opts) != 0)
         exit (1);

--- a/test/ipc-frontend-dbus_unit.c
+++ b/test/ipc-frontend-dbus_unit.c
@@ -65,7 +65,6 @@ ipc_frontend_dbus_type_test (void **state)
 gint
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (ipc_frontend_dbus_type_test,
                                          ipc_frontend_dbus_setup,

--- a/test/ipc-frontend_unit.c
+++ b/test/ipc-frontend_unit.c
@@ -200,7 +200,6 @@ ipc_frontend_disconnect_test (void **state)
 gint
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (ipc_frontend_type_test,
                                          ipc_frontend_setup,

--- a/test/message-queue_unit.c
+++ b/test/message-queue_unit.c
@@ -149,7 +149,6 @@ message_queue_thread_unblock_test (void **state)
 int
 main(void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (message_queue_allocate_test),
         cmocka_unit_test_setup_teardown (message_queue_enqueue_dequeue_test,

--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -498,7 +498,6 @@ resource_manager_getcap_gap_max_test (void **state)
 int
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (resource_manager_type_test,
                                          resource_manager_setup,

--- a/test/response-sink_unit.c
+++ b/test/response-sink_unit.c
@@ -29,7 +29,6 @@ response_sink_allocate_test (void **state)
 int
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (response_sink_allocate_test),
     };

--- a/test/session-entry_unit.c
+++ b/test/session-entry_unit.c
@@ -111,7 +111,6 @@ session_entry_get_handle_test (void **state)
 gint
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (session_entry_type_test,
                                          session_entry_setup,

--- a/test/session-list_unit.c
+++ b/test/session-list_unit.c
@@ -307,7 +307,6 @@ session_list_claim_fail_test (void **state)
 gint
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (session_list_type_test,
                                          session_list_setup,

--- a/test/tabrmd-init_unit.c
+++ b/test/tabrmd-init_unit.c
@@ -28,29 +28,12 @@
  * test whether or not the gmain loop is killed by code under test.
  */
 static gboolean gmain_quit = FALSE;
-/*
- * This is a hack to work around weirdness in the util module. We can call
- * the util_init function only once. Since we're mocking functions used by
- * util_init we must call it from a setup function (not the main function)
- * since we need to push values onto the mock stack.
- */
-static gboolean init = FALSE;
-
 static int
 test_setup (void **state)
 {
     UNUSED_PARAM (state);
-    void *rand_bytes = (void*)1;
 
     gmain_quit = FALSE;
-
-    if (!init) {
-        will_return (__wrap_random_seed_from_file, 0);
-        will_return (__wrap_random_get_bytes, rand_bytes);
-        will_return (__wrap_random_get_bytes, sizeof (rand_bytes));
-        util_init ();
-        init = TRUE;
-    }
 
     return 0;
 }
@@ -104,14 +87,6 @@ init_thread_func_setup (void **state)
     data_src.options.flush_all = TRUE;
     memcpy (&data, &data_src, sizeof (data));
     g_mutex_init (&data.init_mutex);
-
-    if (!init) {
-        void *rand_bytes = (void*)1;
-        will_return (__wrap_random_seed_from_file, 0);
-        will_return (__wrap_random_get_bytes, rand_bytes);
-        will_return (__wrap_random_get_bytes, sizeof (rand_bytes));
-        util_init ();
-    }
 
     return 0;
 }

--- a/test/tcti-factory_unit.c
+++ b/test/tcti-factory_unit.c
@@ -131,7 +131,6 @@ tcti_factory_create_test (void **state)
 gint
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (tcti_factory_type_test,
                                          tcti_factory_setup,

--- a/test/tcti-tabrmd-receive_unit.c
+++ b/test/tcti-tabrmd-receive_unit.c
@@ -655,7 +655,6 @@ tcti_tabrmd_receive_partial_reads (void **state)
 int
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (tcti_tabrmd_poll_fd_ready_pollin),
         cmocka_unit_test (tcti_tabrmd_poll_fd_ready_pollpri),

--- a/test/tcti_unit.c
+++ b/test/tcti_unit.c
@@ -96,7 +96,6 @@ tcti_receive_test (void **state)
 gint
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (tcti_type_test,
                                          tcti_setup,

--- a/test/tpm2-command_unit.c
+++ b/test/tpm2-command_unit.c
@@ -628,7 +628,6 @@ tpm2_command_get_cap_no_count (void **state)
 gint
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (tpm2_command_type_test,
                                          tpm2_command_setup,

--- a/test/tpm2-response_unit.c
+++ b/test/tpm2-response_unit.c
@@ -411,7 +411,6 @@ tpm2_response_set_handle_no_handle_test (void **state)
 gint
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown (tpm2_response_type_test,
                                          tpm2_response_setup,

--- a/test/tss2-tcti-tabrmd_unit.c
+++ b/test/tss2-tcti-tabrmd_unit.c
@@ -868,7 +868,6 @@ tcti_tabrmd_set_locality_bad_sequence_test (void **state)
 int
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (tcti_tabrmd_init_size_test),
         cmocka_unit_test (tcti_tabrmd_init_success_return_value_test),

--- a/test/util_unit.c
+++ b/test/util_unit.c
@@ -668,7 +668,6 @@ read_tpm_buf_alloc_eof_test (void **state)
 gint
 main (void)
 {
-    util_init ();
     const struct CMUnitTest tests[] = {
         cmocka_unit_test (write_in_one),
         cmocka_unit_test (write_in_two),


### PR DESCRIPTION
xor worked fine for this purpose but the crypto folks get itchy if we
use anything other than a standard hash algorithm. Luckily glib has a
sha256 implementation that I didn't know about till now. This function
must truncate the hash to a void* so we increase the probability of a
collision. Since this value is never used for anything other than
debug output it's sufficient for the purpose.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>