### PR TITLE
Fix LGTM alerts

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -3,6 +3,9 @@
  * Copyright (c) 2017, Intel Corporation
  * All rights reserved.
  */
+#ifndef LOGGING_H
+#define LOGGING_H
+
 #include <glib.h>
 
 /* Macro to log "critical" events, then exit indicating failure. */
@@ -24,3 +27,4 @@ syslog_log_handler (const char     *log_domain,
                     gpointer        log_config_list);
 int get_enabled_log_levels (void);
 gint set_logger (gchar *name);
+#endif /* LOGGING_H */

--- a/src/util.c
+++ b/src/util.c
@@ -230,7 +230,7 @@ read_tpm_buffer_alloc (GInputStream *istream,
         switch (ret) {
         case EPROTO:
             size_tmp = get_command_size (buf);
-            if (size_tmp < TPM_HEADER_SIZE && size_tmp > UTIL_BUF_MAX) {
+            if (size_tmp < TPM_HEADER_SIZE || size_tmp > UTIL_BUF_MAX) {
                 g_warning ("%s: tpm buffer size is ouside of acceptable bounds: %zd",
                            __func__, size_tmp);
                 goto err_out;


### PR DESCRIPTION
Fix two alerts uncovered by lgtm.com: add a [header guard for `logging.h`](https://lgtm.com/projects/g/tpm2-software/tpm2-abrmd/snapshot/bd4a3d154e6555b86ca83c9b6ea85e256ac0b0cb/files/src/logging.h#x2777fce244dcef2f:1) and fix an [incorrect error check in `util.c`](https://lgtm.com/projects/g/tpm2-software/tpm2-abrmd/snapshot/bd4a3d154e6555b86ca83c9b6ea85e256ac0b0cb/files/src/util.c#x6b4a6191a554e98f:1).