### PR TITLE
configure: add -02 to flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ script :
 
 after_success:
   - |
-    if [ "${CONFIG_EXTRA}" == "--enable-code-coverage" ]; then
+    if [[ "${CONFIG_EXTRA}" = *"--enable-code-coverage"* ]]; then
         bash <(curl -s https://codecov.io/bash)
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
 matrix:
   include:
     - compiler: clang
-      env: SCANBUILD="scan-build --status-bugs" CFLAGS=-D_REENTRANT CONFIG_EXTRA=--enable-code-coverage MAKE_TARGET=check
+      env: SCANBUILD="scan-build --status-bugs" CFLAGS=-D_REENTRANT CONFIG_EXTRA="--enable-code-coverage --disable-defaultflags" MAKE_TARGET=check
     - compiler: gcc
       env: SCANBUILD= MAKE_TARGET=distcheck
 

--- a/configure.ac
+++ b/configure.ac
@@ -143,6 +143,7 @@ AS_IF([test "x$enable_defaultflags" = "xyes"],
       # preprocessor / compiler / linker flags
       #   these macros are defined in m4/flags.m4
       AX_ADD_FORTIFY_SOURCE
+      AX_ADD_COMPILER_FLAG([-O2])
       AX_ADD_COMPILER_FLAG([-Wall])
       AX_ADD_COMPILER_FLAG([-Wextra])
       AX_ADD_COMPILER_FLAG([-Werror])


### PR DESCRIPTION
To fix FORTIFY_SOURCE requiring optimization errors:
/usr/include/features.h:382:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
  382 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:2451: src/tabrmd.o] Error 1

Add -O2 to the flags.

Fixes: #652

Signed-off-by: William Roberts <william.c.roberts@intel.com>