### PR TITLE
Release debug macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
 matrix:
   include:
     - compiler: clang
-      env: SCANBUILD="scan-build --status-bugs" CFLAGS=-D_REENTRANT CONFIG_EXTRA="--enable-code-coverage --disable-defaultflags" MAKE_TARGET=check
+      env: SCANBUILD="scan-build --status-bugs" CFLAGS=-D_REENTRANT CONFIG_EXTRA="--enable-code-coverage --disable-defaultflags --enable-debug" MAKE_TARGET=check
     - compiler: gcc
       env: SCANBUILD= MAKE_TARGET=distcheck
 

--- a/bootstrap
+++ b/bootstrap
@@ -3,3 +3,9 @@
 
 git describe --tags --always --dirty > VERSION
 autoreconf --install --sym
+
+if grep "Invalid policy. Valid policies: git-directory, minor-version." configure >/dev/null; then
+    echo "ERROR: ax_is_release.m4 is outdated. ./configure will fail."
+    echo "Please download from http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2019.01.06.tar.xz"
+    exit 1
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -151,9 +151,6 @@ AS_IF([test "x$enable_defaultflags" = "xyes"],
       AX_ADD_COMPILER_FLAG([-Wformat])
       AX_ADD_COMPILER_FLAG([-Wformat-security])
       AX_ADD_COMPILER_FLAG([-Wno-missing-braces])
-      # work around for Glib usage of function pointers type casting
-      #   https://bugzilla.gnome.org/show_bug.cgi?id=793272
-      AX_ADD_COMPILER_FLAG([-Wno-cast-function-type])
       AX_ADD_COMPILER_FLAG([-fdata-sections])
       AX_ADD_COMPILER_FLAG([-ffunction-sections])
       AX_ADD_TOOLCHAIN_FLAG([-fstack-protector-all])

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,8 @@ AC_INIT([tpm2-abrmd],
         [],
         [https://github.com/tpm2-software/tpm2-abrmd])
 AC_CONFIG_MACRO_DIR([m4])
+AX_IS_RELEASE(dash-version)
+AX_CHECK_ENABLE_DEBUG([info])
 AC_PROG_CC
 AC_PROG_LN_S
 AC_USE_SYSTEM_EXTENSIONS
@@ -142,11 +144,13 @@ AS_IF([test "x$enable_defaultflags" = "xyes"],
       [
       # preprocessor / compiler / linker flags
       #   these macros are defined in m4/flags.m4
-      AX_ADD_FORTIFY_SOURCE
-      AX_ADD_COMPILER_FLAG([-O2])
+      AS_IF([test "x$enable_debug" = "xno"],
+            [AX_ADD_FORTIFY_SOURCE
+             AX_ADD_COMPILER_FLAG([-O2])])
       AX_ADD_COMPILER_FLAG([-Wall])
       AX_ADD_COMPILER_FLAG([-Wextra])
-      AX_ADD_COMPILER_FLAG([-Werror])
+      AS_IF([test "x$ax_is_release" = "xno"],
+            [AX_ADD_COMPILER_FLAG([-Werror])])
       AX_ADD_COMPILER_FLAG([-std=gnu99])
       AX_ADD_COMPILER_FLAG([-Wformat])
       AX_ADD_COMPILER_FLAG([-Wformat-security])

--- a/src/command-source.c
+++ b/src/command-source.c
@@ -19,6 +19,10 @@
 #include "tpm2-header.h"
 #include "util.h"
 
+#ifndef G_SOURCE_FUNC
+#define G_SOURCE_FUNC(x) ((GSourceFunc)(void*)x)
+#endif
+
 enum {
     PROP_0,
     PROP_COMMAND_ATTRS,
@@ -256,7 +260,7 @@ command_source_on_new_connection (ConnectionManager   *connection_manager,
     g_source_attach (data->source, self->main_context);
     data->self = self;
     g_source_set_callback (data->source,
-                           (GSourceFunc)command_source_on_input_ready,
+                           G_SOURCE_FUNC (command_source_on_input_ready),
                            data,
                            NULL);
     /*


### PR DESCRIPTION
Upstream tpm2-tss has been using these macros for some time. This resolves #640. The only interesting stuff here is that we must now explicitly configure the clang / scan-build build to enable debug per guidance here: https://clang-analyzer.llvm.org/scan-build.html#recommended_debug