### PR TITLE
test: replace netstat by ss

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,10 @@ AS_IF([test "x$enable_integration" = "xyes"],
         [AC_CHECK_PROG([tpm_server], [tpm_server], [yes], [no])
          AS_IF([test "x$tpm_server" != "xyes"],
              [AC_MSG_ERROR([Integration tests enabled but tpm_server not found, try setting PATH])],
-             [AC_MSG_NOTICE([Integration tests will be executed against the TPM2 simulator.])])],
+             [AC_MSG_NOTICE([Integration tests will be executed against the TPM2 simulator.])])
+         AC_CHECK_PROG([ss], [ss], [yes], [no])
+         AS_IF([test "x$ss" != "xyes"],
+             [AC_MSG_ERROR([Integration tests require the ss executable to be installed.])])],
         [AC_MSG_NOTICE([Integration tests will be executed against the TPM device.])])])
 AM_CONDITIONAL([ENABLE_INTEGRATION],[test "x$enable_integration" = "xyes"])
 

--- a/scripts/int-test-setup.sh
+++ b/scripts/int-test-setup.sh
@@ -108,9 +108,9 @@ in
             sleep 1 # give daemon time to bind to ports
             PID=$(cat ${SIM_PID_FILE})
             echo "simulator PID: ${PID}";
-            netstat -ltpn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_DATA}"
+            ss -lt4pn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_DATA}"
             ret_data=$?
-            netstat -ltpn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_CMD}"
+            ss -lt4pn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_CMD}"
             ret_cmd=$?
             if [ \( $ret_data -eq 0 \) -a \( $ret_cmd -eq 0 \) ]; then
                 echo "Simulator with PID ${PID} bound to port ${SIM_PORT_DATA} and " \


### PR DESCRIPTION
Use `ss` instead of the deprecated `netstat` in the integration tests like it is already done for [other tpm2-software projects](https://github.com/tpm2-software/tpm2-tss/pull/1234).