### PR TITLE
tabrmd-init: Exit with EX_IOERR when IPC fails to connect.

### DIFF
--- a/src/tabrmd-init.h
+++ b/src/tabrmd-init.h
@@ -26,6 +26,7 @@ typedef struct gmain_data {
     ResponseSink           *response_sink;
     GMutex                  init_mutex;
     IpcFrontend            *ipc_frontend;
+    gboolean                ipc_disconnected;
 } gmain_data_t;
 
 gpointer
@@ -34,6 +35,6 @@ void
 gmain_data_cleanup (gmain_data_t *data);
 void
 on_ipc_frontend_disconnect (IpcFrontend *ipc_frontend,
-                            GMainLoop   *loop);
+                            gmain_data_t *data);
 
 #endif /* TABRMD_INIT_H */

--- a/test/tabrmd-init_unit.c
+++ b/test/tabrmd-init_unit.c
@@ -60,11 +60,11 @@ on_ipc_frontend_disconnect_test (void **state)
 {
     UNUSED_PARAM (state);
     IpcFrontend *ipc_frontend = ID_IPCFRONT;
-    GMainLoop *loop = ID_GMAIN;
+    gmain_data_t data = { .loop = ID_GMAIN, };
 
     will_return (__wrap_g_main_loop_is_running, TRUE);
     will_return (__wrap_g_main_loop_quit, TRUE);
-    on_ipc_frontend_disconnect (ipc_frontend, loop);
+    on_ipc_frontend_disconnect (ipc_frontend, &data);
     assert_true (gmain_quit);
 }
 


### PR DESCRIPTION
When the IPC mechanism fails to connect the tabrmd-init module receives
an event from the IpcFrontend object and then kills off the GMainLoop.
The current implementation provides no way for the main function to know
why the loop was killed off and so the it exits with a status of 0
(EXIT_SUCCESS) which causes systemd to restart the daemon. This causes a
restart loop.

This patch adds a boolean to the gmain_data_t structure that the
callback sets when the IPC disconnects. This allows the main function to
check for the flag when the GMainLoop terminates and return a meaningful
exit code (EX_IOERR). This exit code will prevent systemd from trying to
restart the daemon.

This resolves #670 

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>