### PR TITLE
Hold Resource Manager until tpm is accessible

### DIFF
--- a/dist/tpm2-abrmd.service.in
+++ b/dist/tpm2-abrmd.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=TPM2 Access Broker and Resource Management Daemon
+After=systemd-udev-settle.service
+Requires=systemd-udev-settle.service
 
 [Service]
 Type=dbus


### PR DESCRIPTION
In testing in an unusual boot scenario it was discovered that
tpm2-abrmd.service was starting before udev had changed ownership
of the TPM device from root to TSS.  This patch changes the
Systemd unit file to force a udev settle before starting the
resource manager service.

Signed-off-by: Steven Clark <davolfman@gmail.com>