### PR TITLE
A couple of fixes for the tpm2-abmrd service unit

### DIFF
--- a/dist/tpm2-abrmd.service.in
+++ b/dist/tpm2-abrmd.service.in
@@ -1,5 +1,8 @@
 [Unit]
 Description=TPM2 Access Broker and Resource Management Daemon
+# This condition is needed when using the device TCTI. If the
+# TCP mssim is used then the condition should be commented out.
+ConditionPathExistsGlob=/dev/tpm*
 
 [Service]
 Type=dbus

--- a/dist/tpm2-abrmd.service.in
+++ b/dist/tpm2-abrmd.service.in
@@ -6,10 +6,6 @@ ConditionPathExistsGlob=/dev/tpm*
 
 [Service]
 Type=dbus
-Restart=always
-# 69=EX_UNAVAILABLE, 71=EX_OSERR, 74=EX_IOERR
-RestartPreventExitStatus=69 71 74
-RestartSec=5
 BusName=com.intel.tss2.Tabrmd
 StandardOutput=syslog
 ExecStart=@SBINDIR@/tpm2-abrmd


### PR DESCRIPTION
This pull-request makes some changes to the tpm2-abrmd service unit as discussed in issue #673.

It does two things: check that a TPM character device exists to start the service and don't attempt to restart the service since it may lead to a restart loop.