### PR TITLE
selinux: Allow name resolve and optional unreserved port name_connect.

### DIFF
--- a/selinux/tabrmd.te
+++ b/selinux/tabrmd.te
@@ -1,9 +1,11 @@
-policy_module(tabrmd, 0.0.1)
+policy_module(tabrmd, 0.0.2)
 
 ########################################
 #
 # Declarations
 #
+
+gen_tunable(`tabrmd_connect_all_unreserved', false)
 
 type tabrmd_t;
 type tabrmd_exec_t;
@@ -13,6 +15,7 @@ allow tabrmd_t self:unix_dgram_socket { create_socket_perms };
 
 dev_rw_tpm(tabrmd_t)
 logging_send_syslog_msg(tabrmd_t)
+sysnet_dns_name_resolve(tabrmd_t)
 
 optional_policy(`
     dbus_stub()
@@ -20,3 +23,6 @@ optional_policy(`
     allow system_dbusd_t tabrmd_t:unix_stream_socket rw_stream_socket_perms;
 ')
 
+tunable_policy(`tabrmd_connect_all_unreserved',`
+    corenet_tcp_connect_all_unreserved_ports(tabrmd_t)
+')


### PR DESCRIPTION
To use the mssim TCTI the daemon must be able to connect to it. The
simulator binds to ports 2321 and 2322 by default. Neither of these are
reserved ports and so they're labeled 'unreserved_port_t' (the default
for ports 1024-32767, and 61001-65535). This commit adds the required
allow rule in a tunable block guarded by a new boolean:
'tabrmd_can_network_connect'. This boolean is disabled by default so use
of mssim TCTI will require enabling it.

Additionally the daemon may need to resolve network names as part of
connecting to the simulator. The available interface from sysnet cannot
be used from within the 'tunable_policy' block (no clue why) and since
this is a largely innocuous thing for a system daemon to do we place it
outside the tunable block.

Signed-off-by: Philip Tricca <flihp@twobit.org>