### PR TITLE
access-broker.c: Log warning instead of error to avoid abort in acces…

### DIFF
--- a/src/access-broker.c
+++ b/src/access-broker.c
@@ -293,8 +293,8 @@ access_broker_get_tpm_properties_fixed (TSS2_SYS_CONTEXT     *sapi_context,
                                  capability_data,
                                  NULL);
     if (rc != TSS2_RC_SUCCESS) {
-        g_error ("Failed to GetCapability: TPM2_CAP_TPM_PROPERTIES, "
-                 "TPM2_PT_FIXED: 0x%x", rc);
+        g_warning ("Failed to GetCapability: TPM2_CAP_TPM_PROPERTIES, "
+                   "TPM2_PT_FIXED: 0x%x", rc);
         return rc;
     }
     /* sanity check the property returned */


### PR DESCRIPTION
…s_broker_get_tpm_properties_fixed

Using g_error() always aborts the program, per documentation:
> Error messages are always fatal, resulting in a call to G_BREAKPOINT() to terminate the application. This function will result in a core
> dump; don't use it for errors you expect. Using this function indicates a bug in your program, i.e. an assertion failure.

I see repeated and continuous aborts happening on this line and it looks strange to call g_error(), which always aborts, yet on the
next line try to return an error code to the caller. This suggests that whoever wrote it originally did not know about or intend for it to
abort the whole program.

Also, the caller of this function already also checks the return code.

Immediately before the crash, I get these logs:
Unsupported device. The device is a TPM 1.2
Tss2_Sys_Startup returned unexpected RC: 0x80001
access_broker_sent_tpm_startup failed: 0x80001
Failed to GetCapability: TPM2_CAP_TPM_PROPERTIES, TPM2_PT_FIXED: 0x80007