### PR TITLE
ci: disable building the FAPI for tpm2-tss

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -3,7 +3,6 @@ extraction:
     prepare:
       packages:
       - autoconf-archive
-      - libssl-dev
     after_prepare:
     - cd "$LGTM_WORKSPACE"
     - mkdir installdir
@@ -11,7 +10,7 @@ extraction:
     - tar xf master.tar.gz
     - cd tpm2-tss-master
     - ./bootstrap
-    - ./configure --prefix="$LGTM_WORKSPACE/installdir/usr" --disable-doxygen-doc
+    - ./configure --prefix="$LGTM_WORKSPACE/installdir/usr" --disable-doxygen-doc --disable-esapi --disable-fapi
     - make install
     - export PKG_CONFIG_PATH="$LGTM_WORKSPACE/installdir/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
     - export LD_LIBRARY_PATH="$LGTM_WORKSPACE/installdir/usr/lib:$LD_LIBRARY_PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - git clone -b master --single-branch https://github.com/01org/tpm2-tss.git
   - pushd tpm2-tss
   - ./bootstrap
-  - ./configure --prefix=${PREFIX} --disable-doxygen-doc --disable-tcti-device --disable-esapi
+  - ./configure --prefix=${PREFIX} --disable-doxygen-doc --disable-tcti-device --disable-esapi --disable-fapi
   - $MAKE && sudo $MAKE install
   - popd # tpm2-tss
   - wget https://download.01.org/tpm2/ibmtpm974.tar.gz


### PR DESCRIPTION
Like the ESAPI, the FAPI is currently not used an pulls in additional dependencies (curl and json-c), see https://github.com/tpm2-software/tpm2-tools/pull/1877, so disable it when building tpm2-tss.