### PR TITLE
(WIP) Use a specific device dependency instead of udev-settle

### DIFF
--- a/dist/tpm2-abrmd.service.in
+++ b/dist/tpm2-abrmd.service.in
@@ -1,9 +1,9 @@
 [Unit]
 Description=TPM2 Access Broker and Resource Management Daemon
-After=systemd-udev-settle.service
-Requires=systemd-udev-settle.service
-# This condition is needed when using the device TCTI. If the
-# TCP mssim is used then the condition should be commented out.
+# These settings are needed when using the device TCTI. If the
+# TCP mssim is used then the settings should be commented out.
+After=dev-tpm0.device
+Requires=dev-tpm0.device
 ConditionPathExistsGlob=/dev/tpm*
 
 [Service]


### PR DESCRIPTION
Pulling in udev-settle affects the entire system – it makes the entire boot process block until all events have been processed. This is usually overkill when we only need one specific device.

Note: This is an incomplete change as I still haven't figured out how to properly add the udev rule into `Makefile.am`, but maybe it would be better to do that in the existing .rules file that's part of tpm2-tss instead?