### PR TITLE
AccessBroker: Gracefully fail if GetCapability doesn't succeed

### DIFF
--- a/src/access-broker.c
+++ b/src/access-broker.c
@@ -293,7 +293,7 @@ access_broker_get_tpm_properties_fixed (TSS2_SYS_CONTEXT     *sapi_context,
                                  capability_data,
                                  NULL);
     if (rc != TSS2_RC_SUCCESS) {
-        g_error ("Failed to GetCapability: TPM2_CAP_TPM_PROPERTIES, "
+        g_warning ("Failed to GetCapability: TPM2_CAP_TPM_PROPERTIES, "
                  "TPM2_PT_FIXED: 0x%x", rc);
         return rc;
     }


### PR DESCRIPTION
If calling Tss2_Sys_GetCapability() to get the TPM capabilities fail, the
access_broker_get_tpm_properties_fixed() function calls g_error() which
emits a signal that terminates the tpm2-abrmd process.

This leads to a core dump and a crash being reported in the journal. Since
the service is D-Bus activated, the daemon will be started for each D-Bus
message which makes the issue even more annoying for users.

So instead of killing the process, just log a warning and return an error
message to the access_broker_get_tpm_properties_fixed() function callers.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>