### PR TITLE
ci: install libgcrypt-dev in CI worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
       - gnulib
       - lcov
       - libcmocka-dev
+      - libgcrypt-dev
       - libglib2.0-dev
       - libdbus-1-dev
       - liburiparser-dev


### PR DESCRIPTION
Upstream tpm2-tss reworked their libgcrypt detection in autoconf adding
the use of the AM_PATH_LIBGCRYPT macro. Previously the dependency on
gcrypt was only apparent if the source tree was configured to use it
(instead of the openssl default). Using this macro however causes the
bootstrap process to be dependent on libgcrypt-dev (where the macro
lives). This requires that we install libgcrypt-dev on CI workers even
though we're not even building libtss2-esys (the library that depends on
the crypto stuff).

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>