### PR TITLE
Travis bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,10 +61,10 @@ install:
   - ./configure --prefix=${PREFIX} --disable-doxygen-doc --disable-tcti-device --disable-esapi --disable-fapi
   - $MAKE && sudo $MAKE install
   - popd # tpm2-tss
-  - wget https://download.01.org/tpm2/ibmtpm974.tar.gz
-  - sha256sum ibmtpm974.tar.gz | grep -q ^8e45d86129a0adb95fee4cee51f4b1e5b2d81ed3e55af875df53f98f39eb7ad7
+  - wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm1563.tar.gz
+  - sha256sum ibmtpm1563.tar.gz | grep -q ^fc3a17f8315c1f47670764f2384943afc0d3ba1e9a0422dacb08d455733bd1e9
   - mkdir ibmtpm
-  - tar axf ibmtpm974.tar.gz -C ibmtpm
+  - tar axf ibmtpm1563.tar.gz -C ibmtpm
   - $MAKE -C ibmtpm/src
   - popd # ${DEPS}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-dist: xenial
+dist: bionic
 
 cache: ccache
 
@@ -7,6 +7,8 @@ addons:
   apt:
     packages:
       - autoconf-archive
+      - clang-tools
+      - coreutils
       - dbus
       - dbus-x11
       - gnulib
@@ -16,7 +18,6 @@ addons:
       - libglib2.0-dev
       - libdbus-1-dev
       - liburiparser-dev
-      - realpath
   coverity_scan:
     project:
       name: 01org/tpm2-abrmd


### PR DESCRIPTION
upgrade travis-ci worker to bionic, update TPM simulator to version 1332 due to build failures with newer compilers