### PR TITLE
ci: Add arm64 arch to build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
       - libcmocka-dev
       - libgcrypt-dev
       - libglib2.0-dev
+      - libltdl-dev
       - libdbus-1-dev
       - liburiparser-dev
   coverity_scan:
@@ -43,9 +44,17 @@ env:
 
 matrix:
   include:
-    - compiler: clang
+    - arch: arm64
+      compiler: clang
+      env: SCANBUILD="scan-build --status-bugs" CFLAGS=-D_REENTRANT CONFIG_EXTRA="--disable-defaultflags --enable-debug" MAKE_TARGET=check
+    - arch: x64
+      compiler: clang
       env: SCANBUILD="scan-build --status-bugs" CFLAGS=-D_REENTRANT CONFIG_EXTRA="--enable-code-coverage --disable-defaultflags --enable-debug" MAKE_TARGET=check
-    - compiler: gcc
+    - arch: arm64
+      compiler: gcc
+      env: SCANBUILD= MAKE_TARGET=distcheck
+    - arch: x64
+      compiler: gcc
       env: SCANBUILD= MAKE_TARGET=distcheck
 
 install:


### PR DESCRIPTION
This commit adds new entries in the build matrix for arm64 arch builds
using both clang and gcc. On arm64 we must install the libltdl-dev
package as well to get the LT_LIB_DLLOAD macro.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>