### PR TITLE
build: Add selinux policy module to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tmp/
 *.log
 *.o
 *.pp
+*.pp.bz2
 *.swp
 *.trs
 AUTHORS


### PR DESCRIPTION
Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>