### PR TITLE
libtss2-rc: Add macro to log erro RCs from calls to Tss2_* functions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,7 @@ AM_CFLAGS = $(EXTRA_CFLAGS) \
     -I$(srcdir)/src -I$(srcdir)/src/include -I$(builddir)/src \
     $(GIO_CFLAGS) $(GLIB_CFLAGS) $(PTHREAD_CFLAGS) \
     $(TSS2_SYS_CFLAGS) $(TSS2_MU_CFLAGS) $(TSS2_TCTILDR_CFLAGS) \
-    $(CODE_COVERAGE_CFLAGS)
+    $(CODE_COVERAGE_CFLAGS) $(TSS2_RC_CFLAGS)
 AM_LDFLAGS = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
 
 TESTS_UNIT = \
@@ -194,7 +194,7 @@ src/ipc-frontend-dbus.c : $(BUILT_SOURCES)
 # -Wno-unused-parameter for automatically-generated tabrmd-generated.c:
 src_libutil_la_CFLAGS  = $(AM_CFLAGS) -Wno-unused-parameter
 src_libutil_la_LIBADD  = $(GIO_LIBS) $(GLIB_LIBS) $(PTHREAD_LIBS) \
-    $(TSS2_SYS_LIBS) $(TSS2_MU_LIBS) $(TSS2_TCTILDR_LIBS)
+    $(TSS2_SYS_LIBS) $(TSS2_MU_LIBS) $(TSS2_TCTILDR_LIBS) $(TSS2_RC_LIBS)
 src_libutil_la_SOURCES = \
     src/tpm2.c \
     src/tpm2.h \

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,7 @@ PKG_CHECK_MODULES([GOBJECT], [gobject-2.0])
 PKG_CHECK_MODULES([TSS2_SYS],[tss2-sys >= 2.0.0])
 PKG_CHECK_MODULES([TSS2_MU],[tss2-mu])
 PKG_CHECK_MODULES([TSS2_TCTILDR],[tss2-tctildr])
+PKG_CHECK_MODULES([TSS2_RC],[tss2-rc])
 AC_ARG_VAR([GDBUS_CODEGEN],[The gdbus-codegen executable.])
 AC_CHECK_PROG([GDBUS_CODEGEN], [gdbus-codegen], [gdbus-codegen])
 AS_IF([test ! -x "$(which $GDBUS_CODEGEN)"],

--- a/src/tcti.c
+++ b/src/tcti.c
@@ -125,9 +125,16 @@ tcti_transmit (Tcti      *self,
                size_t     size,
                uint8_t   *command)
 {
-    return Tss2_Tcti_Transmit (self->tcti_context,
-                               size,
-                               command);
+    TSS2_RC rc;
+
+    rc = Tss2_Tcti_Transmit (self->tcti_context,
+                             size,
+                             command);
+    if (rc != TSS2_RC_SUCCESS) {
+        RC_WARN ("Tss2_Tcti_Transmit", rc);
+    }
+
+    return rc;
 }
 TSS2_RC
 tcti_receive (Tcti      *self,
@@ -135,8 +142,15 @@ tcti_receive (Tcti      *self,
               uint8_t   *response,
               int32_t    timeout)
 {
-    return Tss2_Tcti_Receive (self->tcti_context,
-                              size,
-                              response,
-                              timeout);
+    TSS2_RC rc;
+
+    rc = Tss2_Tcti_Receive (self->tcti_context,
+                            size,
+                            response,
+                            timeout);
+    if (rc != TSS2_RC_SUCCESS) {
+        RC_WARN ("Tss2_Tcti_Receive", rc);
+    }
+
+    return rc;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -8,6 +8,7 @@
 
 #include <glib.h>
 #include <gio/gio.h>
+#include <tss2/tss2_rc.h>
 #include <tss2/tss2_tpm2_types.h>
 
 #include "control-message.h"
@@ -47,6 +48,16 @@
 #define UTIL_BUF_MAX  8*UTIL_BUF_SIZE
 
 #define prop_str(val) val ? "set" : "clear"
+
+/*
+ * Print warning message for a given response code.
+ * Parameters:
+ *   cmd: string name of Tss2_* function that produced the RC
+ *   rc: response code from function 'cmd'
+ */
+#define RC_WARN(cmd, rc) \
+    g_warning ("[%s:%d] %s failed: %s (RC: 0x%" PRIx32 ")", \
+               __FILE__, __LINE__, cmd, Tss2_RC_Decode (rc), rc)
 
 typedef struct {
     char *key;


### PR DESCRIPTION
The logging in the lower layers that make calls to Tss2_Tcti_* and
Tss2_Sys_* functions was a bit fragmented. This commit adds a common
logging macro that uses libtss2-rc to decode the response codes when
appropriate. Some minor cleanup is included as well.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>