### PR TITLE
Enable unit and integration tests on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,28 @@
+task:
+  env:
+    CFLAGS: -I/usr/local/include
+    LDFLAGS: -L/usr/local/lib
+    LD_LIBRARY_PATH: /usr/local/lib
+    PKG_CONFIG_PATH: "/usr/local/lib/pkgconfig:/usr/local/libdata/pkgconfig"
+    ibmtpm_name: ibmtpm1563
+  freebsd_instance:
+    matrix:
+      image_family: freebsd-12-1-snap
+  install_script:
+    - pkg upgrade -y
+    - pkg install -y bash gmake coreutils libtool pkgconf autoconf autoconf-archive openssl libgcrypt
+    - pkg install -y automake glib expat dbus dbus-glib cmocka wget git gettext-runtime tpm2-tss
+    - wget --quiet --show-progress --progress=dot:giga "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz"
+    - shasum -a256 $ibmtpm_name.tar.gz | grep ^fc3a17f8315c1f47670764f2384943afc0d3ba1e9a0422dacb08d455733bd1e9
+    - mkdir -p $ibmtpm_name
+    - tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name && cd $ibmtpm_name/src
+    - sed -i '' -e 's/gcc/clang/g' makefile
+    - sed -i '' -e 's/-Wall //g' makefile
+    - sed -i '' -e 's/-Werror //g' makefile
+    - gmake -j && cp tpm_server /usr/bin/
+    - cd -
+    - rm -rf $ibmtpm_name $ibmtpm_name.tar.gz
+  script:
+    - ./bootstrap
+    - ./configure --enable-unit=yes --enable-integration=yes --disable-dependency-tracking
+    - gmake -j check || { cat test-suite.log; exit 1; }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/tpm2-software/tpm2-abrmd.svg?branch=master)](https://travis-ci.org/tpm2-software/tpm2-abrmd)
+[![Linux Build Status](https://travis-ci.org/tpm2-software/tpm2-abrmd.svg?branch=master)](https://travis-ci.org/tpm2-software/tpm2-abrmd)
+[![FreeBSD Build Status](https://api.cirrus-ci.com/github/tpm2-software/tpm2-abrmd.svg?branch=master)](https://cirrus-ci.com/github/tpm2-software/tpm2-abrmd)
 [![Coverity Scan](https://img.shields.io/coverity/scan/3997.svg)](https://scan.coverity.com/projects/01org-tpm2-abrmd)
 [![codecov](https://codecov.io/gh/tpm2-software/tpm2-abrmd/branch/master/graph/badge.svg)](https://codecov.io/gh/tpm2-software/tpm2-abrmd)
 [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/tpm2-software/tpm2-abrmd.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tpm2-software/tpm2-abrmd/context:cpp)

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,18 @@ AC_CHECK_PROG([GDBUS_CODEGEN], [gdbus-codegen], [gdbus-codegen])
 AS_IF([test ! -x "$(which $GDBUS_CODEGEN)"],
       [AC_MSG_ERROR([*** gdbus-codegen is required to build tpm2-abrmd])])
 
+# Check OS and set library and compile flags accordingly
+case "${host_os}" in
+    *bsd* | *BSD*)
+        HOSTOS='BSD'
+        ;;
+    *)
+        #Assume linux
+        HOSTOS='Linux'
+        ;;
+esac
+AC_SUBST([HOSTOS])
+
 AX_CODE_COVERAGE
 m4_ifdef([_AX_CODE_COVERAGE_RULES],
          [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [true])],
@@ -173,9 +185,11 @@ AS_IF([test "x$enable_integration" = "xyes"],
          AS_IF([test "x$tpm_server" != "xyes"],
              [AC_MSG_ERROR([Integration tests enabled but tpm_server not found, try setting PATH])],
              [AC_MSG_NOTICE([Integration tests will be executed against the TPM2 simulator.])])
-         AC_CHECK_PROG([ss], [ss], [yes], [no])
+         AS_IF([test "$HOSTOS" = "Linux"],
+           [AC_CHECK_PROG(ss, [ss], [yes], [no])],
+           [AC_CHECK_PROG(ss, [sockstat], [yes], [no])])
          AS_IF([test "x$ss" != "xyes"],
-             [AC_MSG_ERROR([Integration tests require the ss executable to be installed.])])],
+             [AC_MSG_ERROR([Integration tests require the sockstat/ss executable to be installed.])])],
         [AC_MSG_NOTICE([Integration tests will be executed against the TPM device.])])])
 AM_CONDITIONAL([ENABLE_INTEGRATION],[test "x$enable_integration" = "xyes"])
 

--- a/src/tpm2-header.h
+++ b/src/tpm2-header.h
@@ -9,6 +9,12 @@
 #include <sys/types.h>
 #include <tss2/tss2_tcti.h>
 
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#else
+#include <endian.h>
+#endif
+
 /* A convenience macro to get us the size of the TPM header. */
 #define TPM_HEADER_SIZE (UINT32)(sizeof (TPM2_ST) + sizeof (UINT32) + sizeof (TPM2_CC))
 

--- a/test/command-source_unit.c
+++ b/test/command-source_unit.c
@@ -6,7 +6,6 @@
 #include <glib.h>
 
 #include <errno.h>
-#include <error.h>
 #include <fcntl.h>
 #include <inttypes.h>
 #include <stdbool.h>

--- a/test/connection-manager_unit.c
+++ b/test/connection-manager_unit.c
@@ -6,7 +6,6 @@
 #include <glib.h>
 
 #include <errno.h>
-#include <error.h>
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/test/connection_unit.c
+++ b/test/connection_unit.c
@@ -6,7 +6,6 @@
 #include <glib.h>
 
 #include <errno.h>
-#include <error.h>
 #include <gio/gunixinputstream.h>
 #include <gio/gunixoutputstream.h>
 #include <stdbool.h>

--- a/test/integration/tpm2-command-flush-no-handle.int.c
+++ b/test/integration/tpm2-command-flush-no-handle.int.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 
 #include <tss2/tss2_sys.h>
+#include <tpm2-header.h>
 
 #include "common.h"
 #include "test.h"

--- a/test/tcti-tabrmd-receive_unit.c
+++ b/test/tcti-tabrmd-receive_unit.c
@@ -5,11 +5,15 @@
 #include <errno.h>
 #include <glib.h>
 #include <inttypes.h>
-#include <poll.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
+#if defined(__FreeBSD__)
+#include <sys/poll.h>
+#else
+#include <poll.h>
+#endif
 
 #include <setjmp.h>
 #include <cmocka.h>
@@ -57,6 +61,12 @@ tcti_tabrmd_poll_fd_ready_pollpri (void **state)
  * This tests the tcti_tabrmd_poll function, ensuring that it returns the
  * expected response code for the POLLRDHUP event.
  */
+
+#if defined(__FreeBSD__)
+#ifndef POLLRDHUP
+#define POLLRDHUP 0x0
+#endif
+#endif
 static void
 tcti_tabrmd_poll_fd_ready_pollrdhup (void **state)
 {

--- a/test/util_unit.c
+++ b/test/util_unit.c
@@ -198,10 +198,14 @@ read_data_teardown (void **state)
 static void
 create_socket_pair_success_test (void **state)
 {
-    int ret, client_fd, server_fd;
+    int ret, client_fd, server_fd, flags = 0;
     UNUSED_PARAM(state);
 
-    ret = create_socket_pair (&client_fd, &server_fd, O_CLOEXEC);
+#if !defined(__FreeBSD__)
+    flags = O_CLOEXEC;
+#endif
+
+    ret = create_socket_pair (&client_fd, &server_fd, flags);
     if (ret == -1)
         g_error ("create_pipe_pair failed: %s", strerror (errno));
     close (client_fd);


### PR DESCRIPTION
* Add include of system endian header file
* configure.ac: add a socket tool check specific to FreeBSD
* tests: make tests more portable