### PR TITLE
util: include inttypes as required by the RC_WARN macro

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -8,6 +8,7 @@
 
 #include <glib.h>
 #include <gio/gio.h>
+#include <inttypes.h>
 #include <tss2/tss2_rc.h>
 #include <tss2/tss2_tpm2_types.h>
 


### PR DESCRIPTION
Signed-off-by: Philip Tricca <flihp@twobit.org>