### PR TITLE
Fix double use of transient handles and debug statements

### DIFF
--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -323,7 +323,7 @@ resource_manager_virt_to_phys_test (void **state)
 
     /* create & populate HandleMap for transient handle */
     vhandle = tpm2_command_get_handle (data->command, 0);
-    entry = handle_map_entry_new (phandle, vhandle);
+    entry = handle_map_entry_new (0, vhandle);
     /* function under test, */
     rc = resource_manager_virt_to_phys (data->resource_manager,
                                         data->command,
@@ -365,7 +365,7 @@ resource_manager_load_handles_test(void **state)
         assert (FALSE);
     }
     for (i = 0; i < handle_count; ++i) {
-        entry = handle_map_entry_new (phandles [i], vhandles [i]);
+        entry = handle_map_entry_new (0, vhandles [i]);
         handle_map_insert (map, vhandles [i], entry);
         g_object_unref (entry);
     }


### PR DESCRIPTION
- Add transient handle debug info

- Fixes: #719: If a transient vhandle is referenced twice in a command we load it only once and flush that loaded object. Previously, we loaded it twice but leaked one loaded object.

Needs backporting to bugfix branches...