### PR TITLE
Remove obsolete setting regarding the Standard Output and Fix typo

### DIFF
--- a/dist/tpm2-abrmd.service.in
+++ b/dist/tpm2-abrmd.service.in
@@ -9,7 +9,6 @@ ConditionPathExistsGlob=/dev/tpm*
 [Service]
 Type=dbus
 BusName=com.intel.tss2.Tabrmd
-StandardOutput=syslog
 ExecStart=@SBINDIR@/tpm2-abrmd
 User=tss
 

--- a/src/resource-manager.c
+++ b/src/resource-manager.c
@@ -222,7 +222,7 @@ resource_manager_load_session_from_handle (ResourceManager *resmgr,
     if (session_entry_state != SESSION_ENTRY_SAVED_RM) {
         g_warning ("%s: Handle in handle area references SessionEntry "
                    "for session in state \"%s\". Must be in state: "
-                   "SESSION_ENTRY_SAVED_RM for us manage it, ignorning.",
+                   "SESSION_ENTRY_SAVED_RM for us manage it, ignoring.",
                    __func__, session_entry_state_to_str (session_entry_state));
         goto out;
     }


### PR DESCRIPTION
The Standard output type "syslog" is obsolete, causing a warning since systemd
version 246 [1].

Please consider using "journal" or "journal+console".

[1] https://github.com/systemd/systemd/blob/master/NEWS#L101

Signed-off-by: SZ Lin (林上智) <szlin@debian.org>