### PR TITLE
test: add support for swtpm simulator and switch CI to it

### DIFF
--- a/.ci/get_deps.sh
+++ b/.ci/get_deps.sh
@@ -15,7 +15,7 @@ if [ ! -d tpm2-tss ]; then
   git clone --depth=1 -b "${TPM2TSS_BRANCH}" "https://github.com/tpm2-software/tpm2-tss.git"
   pushd tpm2-tss
   ./bootstrap
-  ./configure --enable-debug
+  ./configure --enable-debug --disable-esys --disable-esapi --disable-fapi
   make -j$(nproc)
   make install
   popd

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,9 +22,16 @@ jobs:
       - name: failure
         if: ${{ failure() }}
         run: cat build/test-suite.log || true
-  arm64v8:
+  multi-arch:
     runs-on: ubuntu-latest
     if: "!contains(github.ref, 'coverity_scan')"
+    strategy:
+      matrix:
+        ARCH: [
+          "ubuntu-20.04.arm32v7",
+          "ubuntu-20.04.arm64v8",
+          "fedora-32.ppc64le"
+        ]
     steps:
       - name: Setup QEMU
         run: |
@@ -34,50 +41,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Launch Container
         env:
-          DOCKER_IMAGE: ubuntu-20.04.arm64v8
+          DOCKER_IMAGE: ${{ matrix.ARCH }}
           TPM2TSS_BRANCH: master
           CC: gcc
-          MAKE_TARGET: distcheck
-        run: ./.ci/ci-runner.sh
-      - name: failure
-        if: ${{ failure() }}
-        run: cat build/test-suite.log || true
-  arm32v7:
-    runs-on: ubuntu-latest
-    if: "!contains(github.ref, 'coverity_scan')"
-    steps:
-      - name: Setup QEMU
-        run: |
-          sudo apt-get install qemu binfmt-support qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Launch Container
-        env:
-          DOCKER_IMAGE: ubuntu-20.04.arm32v7
-          TPM2TSS_BRANCH: master
-          CC: gcc
-          MAKE_TARGET: distcheck
-        run: ./.ci/ci-runner.sh
-      - name: failure
-        if: ${{ failure() }}
-        run: cat build/test-suite.log || true
-  ppc64le:
-    runs-on: ubuntu-latest
-    if: "!contains(github.ref, 'coverity_scan')"
-    steps:
-      - name: Setup QEMU
-        run: |
-          sudo apt-get install qemu binfmt-support qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Launch Container
-        env:
-          DOCKER_IMAGE: fedora-32.ppc64le
-          TPM2TSS_BRANCH: master
-          CC: gcc
-          MAKE_TARGET: distcheck
+          MAKE_TARGET: check
         run: ./.ci/ci-runner.sh
       - name: failure
         if: ${{ failure() }}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,9 +21,8 @@ your distro provides are installed for these features.
 The following dependencies are required only if the test suite is being built
 and executed.
 * cmocka unit test framework
-* Microsoft / IBM Software TPM2 simulator version 974 as packaged by IBM
-for Linux:
-https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm974.tar
+* [swtpm](https://github.com/stefanberger/swtpm) or
+  [tpm_server](https://sourceforge.net/projects/ibmswtpm2/) TPM2 simulator
 * Alternately, run the test suite on a real TPM hardware, with a safety
 attention described below.
 
@@ -190,23 +189,16 @@ The next two subsections describe these two configurations:
 ### Run Integration Tests: `--enable-integration`
 If the configure script is passed the `--enable-integration` option then the
 test harness will execute the integration tests against the software TPM2
-simulator. The configure script will check for the existance of the software
-TPM2 simulator executable `tpm_server` on the PATH. An instance of the
-simulator will be created for each test executable to allow the parallel
-execution of test cases.
+simulator. The configure script will check for the existance of one of the
+software TPM2 simulator executables `swtpm` or `tpm_server` on the PATH. An
+instance of the simulator will be created for each test executable to allow the
+parallel execution of test cases.
 
 This is the recommended integration test configuration. It requires that you
 first download and compile the TPM2 software simulator as documented by the
-simulators maintainers. Once you have the `tpm_server` built, you must ensure
-that it is discoverable via the PATH environment variable when the
+simulators' maintainers. Once you have `swtpm` or `tpm_server` built, you must
+ensure that it is discoverable via the PATH environment variable when the
 `./configure` script is run.
-
-**NOTE**: The `--with-simulatorbin` option does not change the default for
-tpm2-abrmd, which is to use TPM hardware.
-To run tpm2-abrmd with the simulator, use:
-```
-$ sudo -u tss /usr/local/sbin/tpm2-abrmd --tcti=mssim
-```
 
 ### Run Integration Tests with hardware TPM2: `--enable-test-hwtpm`
 It's possible to run the integration tests against "real" TPM2 hardware, not

--- a/Makefile.am
+++ b/Makefile.am
@@ -87,10 +87,7 @@ INT_LOG_FLAGS = --tabrmd-tcti=$(TABRMD_TCTI)
 if ENABLE_INTEGRATION
 noinst_LTLIBRARIES += $(libtest)
 TESTS += $(TESTS_INTEGRATION)
-if HWTPM
-TABRMD_TCTI = device
-else
-TABRMD_TCTI = mssim
+if !HWTPM
 TESTS += $(TESTS_INTEGRATION_NOHW)
 endif
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -181,10 +181,12 @@ AC_ARG_ENABLE([integration],
     [enable_integration=no])
 AS_IF([test "x$enable_integration" = "xyes"],
     [AS_IF([test "x$enable_test_hwtpm" = "xno"],
-        [AC_CHECK_PROG([tpm_server], [tpm_server], [yes], [no])
-         AS_IF([test "x$tpm_server" != "xyes"],
-             [AC_MSG_ERROR([Integration tests enabled but tpm_server not found, try setting PATH])],
-             [AC_MSG_NOTICE([Integration tests will be executed against the TPM2 simulator.])])
+        [AC_CHECK_PROG([swtpm], [swtpm], [yes], [no])
+         AC_CHECK_PROG([tpm_server], [tpm_server], [yes], [no])
+         AS_IF([test "$swtpm" = yes], [TABRMD_TCTI=swtpm],
+               [AS_IF([test "$tpm_server" = yes], [TABRMD_TCTI=mssim],
+                      [AC_MSG_ERROR([Integration tests require swtpm or tpm_server to be installed.])])])
+         AC_SUBST([TABRMD_TCTI])
          AS_IF([test "$HOSTOS" = "Linux"],
            [AC_CHECK_PROG(ss, [ss], [yes], [no])],
            [AC_CHECK_PROG(ss, [sockstat], [yes], [no])])

--- a/dist/tpm2-abrmd.service.in
+++ b/dist/tpm2-abrmd.service.in
@@ -3,7 +3,7 @@ Description=TPM2 Access Broker and Resource Management Daemon
 After=systemd-udev-settle.service
 Requires=systemd-udev-settle.service
 # This condition is needed when using the device TCTI. If the
-# TCP mssim is used then the condition should be commented out.
+# TCP swtpm or mssim is used then the condition should be commented out.
 ConditionPathExistsGlob=/dev/tpm*
 
 [Service]

--- a/man/tpm2-abrmd.8.in
+++ b/man/tpm2-abrmd.8.in
@@ -91,19 +91,19 @@ This is equivalent to:
 .br
 .B tpm2-abrmd --tcti="libtss2-tcti-device.so.0:/dev/tpm0"
 .TP
-Have daemon use Microsoft/IBM TPM2 Simulator tcti library
-'libtss2-tcti-mssim.so.0'.
-This connects to a TPM2 simulator via a TCP mssim.
+Have daemon use swtpm TPM2 Simulator tcti library
+'libtss2-tcti-swtpm.so.0'.
+This connects to a TPM2 simulator via a TCP swtpm.
 .br
-.B tpm2-abrmd --tcti="mssim"
+.B tpm2-abrmd --tcti="swtpm"
 .br
-.B tpm2-abrmd --tcti="libtss2-tcti-mssim.so.0"
+.B tpm2-abrmd --tcti="libtss2-tcti-swtpm.so.0"
 .TP
-Have daemon use tcti library 'libtss2-tcti-mssim.so.0' and config string
+Have daemon use tcti library 'libtss2-tcti-swtpm.so.0' and config string
 'host=127.0.0.1,port=5555':
-.B tpm2-abrmd --tcti=mssim:host=127.0.0.1,port=5555"
+.B tpm2-abrmd --tcti=swtpm:host=127.0.0.1,port=5555"
 .br
-.B tpm2-abrmd --tcti="libtss2-tcti-mssim.so.0:host=127.0.0.1,port=5555"
+.B tpm2-abrmd --tcti="libtss2-tcti-swtpm.so.0:host=127.0.0.1,port=5555"
 .SH AUTHOR
 Philip Tricca <philip.b.tricca@intel.com>
 .SH "SEE ALSO"

--- a/scripts/int-test-funcs.sh
+++ b/scripts/int-test-funcs.sh
@@ -68,8 +68,16 @@ simulator_start ()
     # simulator port is a random port between 1024 and 65535
 
     cd ${sim_tmp_dir}
-    daemon_start "${sim_bin}" "-port ${sim_port}" "${sim_log_file}" \
-        "${sim_pid_file}" ""
+    case "$sim_bin" in
+        *swtpm) daemon_start "$sim_bin" "socket --tpm2 --server port=$sim_port \
+                             --ctrl type=tcp,port=$((sim_port + 1)) \
+                             --flags not-need-init --tpmstate dir=$PWD \
+                             --seccomp action=none" \
+                             "$sim_log_file" "$sim_pid_file";;
+        *tpm_server) daemon_start "$sim_bin" "-port $sim_port" \
+                                  "$sim_log_file" "$sim_pid_file";;
+        *) echo "Unknown TPM simulator $sim_bin"; return 1;;
+    esac
     local ret=$?
     cd -
     return $ret


### PR DESCRIPTION
`libtss2-tcti-swtpm` is available in tpm2-tss 3.0.0. Keep support for `libtss2-tcti-mssim` to allow running the integration tests with older tpm2-tss versions as well, but prefer swtpm if it is available.