### PR TITLE
ci: fix LGTM configuration

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -3,6 +3,7 @@ extraction:
     prepare:
       packages:
       - autoconf-archive
+      - libssl-dev
     after_prepare:
     - cd "$LGTM_WORKSPACE"
     - mkdir installdir


### PR DESCRIPTION
The analysis currently [fails](https://lgtm.com/projects/g/tpm2-software/tpm2-abrmd/logs/rev/01a3f6297261085b8ff5b6deb3fbacf14b5e50d6/lang:cpp/stage:Build%20child_01a3f6297261085b8ff5b6deb3fbacf14b5e50d6) due to the missing dependency `libssl-dev`.