### PR TITLE
ResourceManager: Avoid double free in resource-manager.c

### DIFF
--- a/src/resource-manager.c
+++ b/src/resource-manager.c
@@ -239,6 +239,7 @@ resource_manager_load_session_from_handle (ResourceManager *resmgr,
         rc = tpm2_response_get_code (response);
         if (rc != TSS2_RC_SUCCESS) {
             flush_session (resmgr, session_entry);
+            goto out;
         }
     }
     if (will_flush) {


### PR DESCRIPTION
Clean up potential double free found by coverity in
resource_manager_load_session_from_handle. If flush_session has been
called, don't call session_list_remove which is already called in
flush_session.

Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>