### PR TITLE
LGTM: fix tss configure flag

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -10,7 +10,7 @@ extraction:
     - tar xf master.tar.gz
     - cd tpm2-tss-master
     - ./bootstrap
-    - ./configure --prefix="$LGTM_WORKSPACE/installdir/usr" --disable-doxygen-doc --disable-esapi --disable-fapi
+    - ./configure --prefix="$LGTM_WORKSPACE/installdir/usr" --disable-doxygen-doc --disable-esys --disable-fapi
     - make install
     - export PKG_CONFIG_PATH="$LGTM_WORKSPACE/installdir/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
     - export LD_LIBRARY_PATH="$LGTM_WORKSPACE/installdir/usr/lib:$LD_LIBRARY_PATH"


### PR DESCRIPTION
Since TSS commit:
  - https://github.com/tpm2-software/tpm2-tss/commit/56f91c8aad91c7b100c6dd08812d051d738c7a01

--disable-esapi was changed to --disable-esys, update the LGTM script so
ESYS is disabled and thus things like libcrypto won't be required.

Fixes LGTM error:
[2020-12-30 16:46:28] [build-err] ++ ./configure --prefix=/opt/work/lgtm-workspace/installdir/usr --disable-doxygen-doc --disable-esapi --disable-fapi
[2020-12-30 16:46:28] [build-err] configure: WARNING: unrecognized options: --disable-esapi
<snip>
[2020-12-30 16:46:38] [build] checking for LIBCRYPTO... no
[2020-12-30 16:46:38] [build-err] configure: error: Package requirements (libcrypto) were not met:
[2020-12-30 16:46:38] [build-err] Package 'libcrypto', required by 'virtual:world', not found
[2020-12-30 16:46:38] [build-err] Consider adjusting the PKG_CONFIG_PATH environment variable if you
[2020-12-30 16:46:38] [build-err] installed software in a non-standard prefix.
[2020-12-30 16:46:38] [build-err] Alternatively, you may set the environment variables LIBCRYPTO_CFLAGS

Signed-off-by: William Roberts <william.c.roberts@intel.com>