### PR TITLE
CI: fix mulit-arch builds

### DIFF
--- a/.ci/docker.run
+++ b/.ci/docker.run
@@ -8,7 +8,7 @@ $DOCKER_BUILD_DIR/.ci/get_deps.sh "$(dirname $DOCKER_BUILD_DIR)"
 pushd $DOCKER_BUILD_DIR
 
 SCANBUILD=""
-CONFIG_OPTS="--enable-unit --enable-integration --disable-silent-rules"
+CONFIG_OPTS="${CONFIG_OPTS:--enable-unit --enable-integration --disable-silent-rules}"
 
 if [ -d build ]; then
   rm -rf build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,9 +22,16 @@ jobs:
       - name: failure
         if: ${{ failure() }}
         run: cat build/test-suite.log || true
-  arm64v8:
+  multi-arch:
     runs-on: ubuntu-latest
     if: "!contains(github.ref, 'coverity_scan')"
+    strategy:
+      matrix:
+        ARCHES: [
+          "ubuntu-20.04.arm32v7",
+          "ubuntu-20.04.arm64v8",
+          "fedora-32.ppc64le"
+        ]
     steps:
       - name: Setup QEMU
         run: |
@@ -34,50 +41,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Launch Container
         env:
-          DOCKER_IMAGE: ubuntu-20.04.arm64v8
+          DOCKER_IMAGE: ${{ matrix.ARCHES }}
           TPM2TSS_BRANCH: master
           CC: gcc
-          MAKE_TARGET: distcheck
-        run: ./.ci/ci-runner.sh
-      - name: failure
-        if: ${{ failure() }}
-        run: cat build/test-suite.log || true
-  arm32v7:
-    runs-on: ubuntu-latest
-    if: "!contains(github.ref, 'coverity_scan')"
-    steps:
-      - name: Setup QEMU
-        run: |
-          sudo apt-get install qemu binfmt-support qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Launch Container
-        env:
-          DOCKER_IMAGE: ubuntu-20.04.arm32v7
-          TPM2TSS_BRANCH: master
-          CC: gcc
-          MAKE_TARGET: distcheck
-        run: ./.ci/ci-runner.sh
-      - name: failure
-        if: ${{ failure() }}
-        run: cat build/test-suite.log || true
-  ppc64le:
-    runs-on: ubuntu-latest
-    if: "!contains(github.ref, 'coverity_scan')"
-    steps:
-      - name: Setup QEMU
-        run: |
-          sudo apt-get install qemu binfmt-support qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Launch Container
-        env:
-          DOCKER_IMAGE: fedora-32.ppc64le
-          TPM2TSS_BRANCH: master
-          CC: gcc
-          MAKE_TARGET: distcheck
+          MAKE_TARGET: check
+          CONFIG_OPTS: "--enable-unit --disable-silent-rules"
         run: ./.ci/ci-runner.sh
       - name: failure
         if: ${{ failure() }}


### PR DESCRIPTION
multi-arch builds seem to be failing because SS isn't working in the
containers. So for now, just run the unit tests on non-x86 container
images.

See bug:
  - https://github.com/tpm2-software/tpm2-software-container/issues/44
  - https://github.com/tpm2-software/tpm2-abrmd/issues/745

Signed-off-by: William Roberts <william.c.roberts@intel.com>