### PR TITLE
tpm2-abrmd.service: remove udev settle

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,11 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AX_RECURSIVE_EVAL([$sbindir], [SBINDIR])
 AC_SUBST([SBINDIR])
 
+AC_PATH_PROG([CHMOD], [chmod])
+AC_SUBST([CHMOD])
+AC_PATH_PROG([CHOWN], [chown])
+AC_SUBST([CHOWN])
+
 AC_CONFIG_FILES([Makefile dist/tss2-tcti-tabrmd.pc dist/tpm2-abrmd.service dist/tpm2-abrmd.preset])
 
 # propagate configure arguments to distcheck

--- a/dist/tpm2-abrmd.service.in
+++ b/dist/tpm2-abrmd.service.in
@@ -1,7 +1,5 @@
 [Unit]
 Description=TPM2 Access Broker and Resource Management Daemon
-After=systemd-udev-settle.service
-Requires=systemd-udev-settle.service
 # This condition is needed when using the device TCTI. If the
 # TCP swtpm or mssim is used then the condition should be commented out.
 ConditionPathExistsGlob=/dev/tpm*
@@ -10,6 +8,14 @@ ConditionPathExistsGlob=/dev/tpm*
 Type=dbus
 BusName=com.intel.tss2.Tabrmd
 ExecStart=@SBINDIR@/tpm2-abrmd
+# There is a chance that the service could start before udev gets a chance
+# to change FS permisions, or a system could be missing the udev rules.
+# This would cause the device node to be inaccessible to the service,
+# causing it to fail to establish the TCTI.
+# Run commands before the service starts while root, to change the fs
+# permissions of /dev/tpm0 change this if using a different TPM for abrmd.
+ExecStartPre=@CHMOD@ 0660 /dev/tpm0
+ExecStartPre=@CHOWN@ tss /dev/tpm0
 User=tss
 
 [Install]


### PR DESCRIPTION
udev settle has been deprecated since systemd version 243[1]. Thus we
need to remove its use and their is no direct replacement. The
requirement on waiting for udev, was so that FS permission rules are run
and the device nodes are accessible to the tpm2-abrmd service. Rather
than require udev, the default configuration of tpm2-abrmd would,
eventually, be to open device /dev/tmp0. Folks needing to configure
another device/tcti would need to alter the service options and the
pre exec options using systemd's builtin override system.

1. https://github.com/systemd/systemd/pull/12267

Fixes: #704

Signed-off-by: William Roberts <william.c.roberts@intel.com>