### PR TITLE
remove udev settle

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ AC_SEARCH_LIBS([dlopen], [dl dld], [], [
 PKG_CHECK_MODULES([GIO], [gio-unix-2.0])
 PKG_CHECK_MODULES([GLIB], [glib-2.0])
 PKG_CHECK_MODULES([GOBJECT], [gobject-2.0])
-PKG_CHECK_MODULES([TSS2_SYS],[tss2-sys >= 2.0.0])
+PKG_CHECK_MODULES([TSS2_SYS],[tss2-sys >= 2.4.0])
 PKG_CHECK_MODULES([TSS2_MU],[tss2-mu])
 PKG_CHECK_MODULES([TSS2_TCTILDR],[tss2-tctildr])
 PKG_CHECK_MODULES([TSS2_RC],[tss2-rc])

--- a/dist/tpm2-abrmd.service.in
+++ b/dist/tpm2-abrmd.service.in
@@ -4,7 +4,6 @@ Description=TPM2 Access Broker and Resource Management Daemon
 # TCP mssim is used then the settings should be commented out.
 After=dev-tpm0.device
 Requires=dev-tpm0.device
-ConditionPathExistsGlob=/dev/tpm*
 
 [Service]
 Type=dbus

--- a/dist/tpm2-abrmd.service.in
+++ b/dist/tpm2-abrmd.service.in
@@ -1,9 +1,9 @@
 [Unit]
 Description=TPM2 Access Broker and Resource Management Daemon
-After=systemd-udev-settle.service
-Requires=systemd-udev-settle.service
-# This condition is needed when using the device TCTI. If the
-# TCP swtpm or mssim is used then the condition should be commented out.
+# These settings are needed when using the device TCTI. If the
+# TCP mssim is used then the settings should be commented out.
+After=dev-tpm0.device
+Requires=dev-tpm0.device
 ConditionPathExistsGlob=/dev/tpm*
 
 [Service]


### PR DESCRIPTION
1. Require tpm2-tss 2.4.0 for the systemd TAG in the udev rules. This will create a device unit we can tether a dependency to.
2. Rebase PR #683 on current master
3. Drop the ConditionPathExistsGlob, since the device unit should provide us the needed dependency and the glob could be triggered by non /dev/tpm0 device.

Fixes: #704