### PR TITLE
test/tcti-connections-max.int: remove unused variable

### DIFF
--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -128,8 +128,6 @@ void
 tcti_free_from_opts (test_opts_t *options,
                      TSS2_TCTI_CONTEXT **tcti_context)
 {
-    TSS2_RC rc;
-
     if (options->tcti_filename != NULL) {
         Tss2_TctiLdr_Finalize (tcti_context);
     } else {


### PR DESCRIPTION
Compilation with GCC 10.2.0 fails with the warning/error:
```
test/integration/context-util.c: In function ‘tcti_free_from_opts’:
test/integration/context-util.c:131:13: error: unused variable ‘rc’ [-Werror=unused-variable]
  131 |     TSS2_RC rc;
      |             ^~
```
Not sure why this is not caught by CI, I'm guessing it's due to different compiler versions?