### PR TITLE
cirrus: update image version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,7 @@ task:
     ibmtpm_name: ibmtpm1563
   freebsd_instance:
     matrix:
-      image_family: freebsd-12-1-snap
+      image_family: freebsd-12-2
   install_script:
     - pkg upgrade -y
     - pkg install -y bash gmake coreutils libtool pkgconf autoconf autoconf-archive openssl


### PR DESCRIPTION
There are some weird CI problems:
https://cirrus-ci.com/task/6694657062076416?command=main#L514
Update image version to stable FreeBSD12.2 version to fix them.