### PR TITLE
tcti: remove extra out param from CreateConnection dbus call

### DIFF
--- a/src/tabrmd.xml
+++ b/src/tabrmd.xml
@@ -3,7 +3,6 @@
 <node>
     <interface name='com.intel.tss2.TctiTabrmd'>
         <method name='CreateConnection'>
-            <arg type='ah' name='fds' direction='out'/>
             <arg type='t'  name='id'  direction='out'/>
         </method>
         <method name='Cancel'>

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -442,7 +442,7 @@ tcti_tabrmd_call_create_connection_sync_fdlist (TctiTabrmd     *proxy,
     GVariant *_ret;
     _ret = g_dbus_proxy_call_with_unix_fd_list_sync (G_DBUS_PROXY (proxy),
         "CreateConnection",
-        g_variant_new ("()"),
+        NULL,
         G_DBUS_CALL_FLAGS_NONE,
         -1,
         NULL,

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -434,7 +434,6 @@ init_tcti_data (TSS2_TCTI_CONTEXT *context)
 
 static gboolean
 tcti_tabrmd_call_create_connection_sync_fdlist (TctiTabrmd     *proxy,
-                                                GVariant      **out_fds,
                                                 guint64        *out_id,
                                                 GUnixFDList   **out_fd_list,
                                                 GCancellable   *cancellable,
@@ -453,7 +452,7 @@ tcti_tabrmd_call_create_connection_sync_fdlist (TctiTabrmd     *proxy,
     if (_ret == NULL) {
         goto _out;
     }
-    g_variant_get (_ret, "(@aht)", out_fds, out_id);
+    g_variant_get (_ret, "(t)", out_id);
     g_variant_unref (_ret);
 _out:
     return _ret != NULL;
@@ -533,14 +532,12 @@ tcti_tabrmd_connect (TSS2_TCTI_CONTEXT *context)
     GError *error = NULL;
     GSocket *sock = NULL;
     GUnixFDList *fd_list = NULL;
-    GVariant *fds_variant = NULL;
     gboolean call_ret;
     guint64 id;
     TSS2_RC rc = TSS2_RC_SUCCESS;
 
     call_ret = tcti_tabrmd_call_create_connection_sync_fdlist (
         TSS2_TCTI_TABRMD_PROXY (context),
-        &fds_variant,
         &id,
         &fd_list,
         NULL,
@@ -575,7 +572,6 @@ tcti_tabrmd_connect (TSS2_TCTI_CONTEXT *context)
         g_socket_connection_factory_create_connection (sock);
     TSS2_TCTI_TABRMD_ID (context) = id;
 out:
-    g_clear_pointer (&fds_variant, g_variant_unref);
     g_clear_error (&error);
     g_clear_object (&sock);
     g_clear_object (&fd_list);

--- a/test/tss2-tcti-tabrmd_unit.c
+++ b/test/tss2-tcti-tabrmd_unit.c
@@ -382,7 +382,7 @@ __wrap_g_dbus_proxy_call_with_unix_fd_list_sync (
     GCancellable *cancellable,
     GError **error)
 {
-    GVariant *variant_array[2] = { 0 }, *variant_tuple;
+    GVariant *variant_array[1] = { 0 }, *variant_tuple;
     gint client_fd;
     guint64 id;
     UNUSED_PARAM(proxy);
@@ -391,19 +391,15 @@ __wrap_g_dbus_proxy_call_with_unix_fd_list_sync (
     UNUSED_PARAM(flags);
     UNUSED_PARAM(timeout_msec);
     UNUSED_PARAM(fd_list);
+    UNUSED_PARAM(out_fd_list);
     UNUSED_PARAM(cancellable);
     UNUSED_PARAM(error);
 
     client_fd = mock_type (gint);
     id = mock_type (guint64);
-
     *out_fd_list = g_unix_fd_list_new_from_array (&client_fd, 1);
-    variant_array[0] = g_variant_new_fixed_array (G_VARIANT_TYPE ("h"),
-                                                  &client_fd,
-                                                  1,
-                                                  sizeof (gint32));
-    variant_array[1] = g_variant_new_uint64 (id);
-    variant_tuple = g_variant_new_tuple (variant_array, 2);
+    variant_array[0] = g_variant_new_uint64 (id);
+    variant_tuple = g_variant_new_tuple (variant_array, 1);
 
     return variant_tuple;
 }


### PR DESCRIPTION
The CreateConnection call takes two out params - fds, which is an array
of file descriptors, and id - connection id of type uint64.
Additionally the client file descriptor, created in the daemon process,
is returned to the client by the virtue of using
g_dbus_method_invocation_return_value_with_unix_fd_list() on one side
and g_dbus_proxy_call_with_unix_fd_list_sync() on the other, which also
takes and returns file descriptors array.
This makes the fds dbus call param redundant so let's remove it.