### PR TITLE
session-entry-state-enum.c: make g_once_init_enter arg non-volatile

### DIFF
--- a/src/session-entry-state-enum.c
+++ b/src/session-entry-state-enum.c
@@ -25,9 +25,9 @@ session_entry_state_to_str (SessionEntryStateEnum state)
 GType
 session_entry_state_enum_get_type (void)
 {
-    static volatile gsize g_define_type_id__volatile = 0;
+    static gsize g_define_type_id = 0;
 
-    if (g_once_init_enter (&g_define_type_id__volatile)) {
+    if (g_once_init_enter (&g_define_type_id)) {
         static const GEnumValue my_enum_values[] = {
             {
                 SESSION_ENTRY_LOADED,
@@ -55,9 +55,9 @@ session_entry_state_enum_get_type (void)
 
         GType session_entry_state_enum_type =
             g_enum_register_static ("SessionEntryStateEnum", my_enum_values);
-        g_once_init_leave (&g_define_type_id__volatile,
+        g_once_init_leave (&g_define_type_id,
                            session_entry_state_enum_type);
     }
 
-    return g_define_type_id__volatile;
+    return g_define_type_id;
 }


### PR DESCRIPTION
According to the [GLib documentation for `g_once_init_enter()`](https://developer.gnome.org/glib/unstable/glib-Threads.html#g-once-init-enter):

> While `location` has a `volatile` qualifier, this is a historical artifact and the pointer passed to it should not be `volatile`.

With GCC 11, making the variable volatile produces a compiler warning/error:
```
src/session-entry-state-enum.c: In function ‘session_entry_state_enum_get_type’:
/usr/include/glib-2.0/glib/gatomic.h:117:5: error: argument 2 of ‘__atomic_load’ discards ‘volatile’ qualifier [-Werror=incompatible-pointer-types]
  117 |     __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST); \
      |     ^~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gthread.h:260:7: note: in expansion of macro ‘g_atomic_pointer_get’
  260 |     (!g_atomic_pointer_get (location) &&                             \
      |       ^~~~~~~~~~~~~~~~~~~~
src/session-entry-state-enum.c:30:9: note: in expansion of macro ‘g_once_init_enter’
   30 |     if (g_once_init_enter (&g_define_type_id__volatile)) {
      |         ^~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```