### PR TITLE
update dependencies

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -4,12 +4,12 @@ extraction:
       packages:
       - autoconf-archive
       - acl
+      - git
     after_prepare:
     - cd "$LGTM_WORKSPACE"
     - mkdir installdir
-    - wget https://github.com/tpm2-software/tpm2-tss/archive/master.tar.gz
-    - tar xf master.tar.gz
-    - cd tpm2-tss-master
+    - git clone https://github.com/tpm2-software/tpm2-tss.git
+    - cd tpm2-tss
     - ./bootstrap
     - ./configure --prefix="$LGTM_WORKSPACE/installdir/usr" --disable-doxygen-doc --disable-esys --disable-fapi
     - make install

--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ PKG_CHECK_MODULES([TSS2_TCTILDR],[tss2-tctildr])
 PKG_CHECK_MODULES([TSS2_RC],[tss2-rc])
 AC_ARG_VAR([GDBUS_CODEGEN],[The gdbus-codegen executable.])
 AC_CHECK_PROG([GDBUS_CODEGEN], [gdbus-codegen], [gdbus-codegen])
-AS_IF([test ! -x "$(which $GDBUS_CODEGEN)"],
+AS_IF([test ! -x "$(command -v  $GDBUS_CODEGEN)"],
       [AC_MSG_ERROR([*** gdbus-codegen is required to build tpm2-abrmd])])
 
 # Check OS and set library and compile flags accordingly


### PR DESCRIPTION
type is a bash builtin, use it over which is not always installed and
missing from the dependency list anyways.

Fixes: #785

Signed-off-by: William Roberts <william.c.roberts@intel.com>