### PR TITLE
lgtm: use git clone over tarball

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -7,9 +7,8 @@ extraction:
     after_prepare:
     - cd "$LGTM_WORKSPACE"
     - mkdir installdir
-    - wget https://github.com/tpm2-software/tpm2-tss/archive/master.tar.gz
-    - tar xf master.tar.gz
-    - cd tpm2-tss-master
+    - git clone https://github.com/tpm2-software/tpm2-tss.git
+    - cd tpm2-tss
     - ./bootstrap
     - ./configure --prefix="$LGTM_WORKSPACE/installdir/usr" --disable-doxygen-doc --disable-esys --disable-fapi
     - make install


### PR DESCRIPTION
The version information needs a full clone of the git repo
as it uses git describe in configure.ac

Signed-off-by: William Roberts <william.c.roberts@intel.com>