### PR TITLE
test/thread_unit.c: add missing return value for test_thread_run()

### DIFF
--- a/test/thread_unit.c
+++ b/test/thread_unit.c
@@ -69,6 +69,8 @@ test_thread_run (void *data)
         g_debug ("test_thread_run after sleep");
     }
     pthread_cleanup_pop (0);
+
+    return NULL;
 }
 /*
  * This function is invoked as part of canceling ('thread_cancel') the Thread.


### PR DESCRIPTION
This fixes the following compiler warning/error:
```
test/thread_unit.c: In function ‘test_thread_run’:
test/thread_unit.c:72:1: error: no return statement in function returning non-void [-Werror=return-type]
   72 | }
      | ^
```