### PR TITLE
.github: Add workflow_dispatch to allow manual CI runs & re-runs.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Linux Build Status
 on:
-  [push, pull_request]
+  [push, pull_request, workflow_dispatch]
 jobs:
   build-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Github actions 'timeout' causing builds to be reported as failed. These
can be corrected up by manually re-running the workflow. This requires
the 'workflow_dispatch' event be 'on'.

Signed-off-by: Philip Tricca <flihp@twobit.org>