### PR TITLE
build: Remove use of 'which' to check for existence of gdbus-codegen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a CHANGELOG](http://keepachangelog.com/)
   - Initialize gerror pointer variable to NULL to fix use of unitialized memory and segfault.
   - Updated missing defaults in manpage.
 
+### Removed
+  - Dependency on 'which' utility in configure.ac.
 
 ### 2.4.0 - 2021-02-08
 ### Added

--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ PKG_CHECK_MODULES([TSS2_TCTILDR],[tss2-tctildr])
 PKG_CHECK_MODULES([TSS2_RC],[tss2-rc])
 AC_ARG_VAR([GDBUS_CODEGEN],[The gdbus-codegen executable.])
 AC_CHECK_PROG([GDBUS_CODEGEN], [gdbus-codegen], [gdbus-codegen])
-AS_IF([test ! -x "$(which $GDBUS_CODEGEN)"],
+AS_IF([test x"$GDBUS_CODEGEN" != x"gdbus-codegen"],
       [AC_MSG_ERROR([*** gdbus-codegen is required to build tpm2-abrmd])])
 
 # Check OS and set library and compile flags accordingly


### PR DESCRIPTION
This is a redundant check. AC_CHECK_PROG already finds the program on
path and ensures that it is executable.

Signed-off-by: Philip Tricca <flihp@twobit.org>