### PR TITLE
tpm2-abrmd.conf: match kernel RM userperms

### DIFF
--- a/dist/tpm2-abrmd.conf
+++ b/dist/tpm2-abrmd.conf
@@ -8,7 +8,20 @@
   <policy user="root">
     <allow own="com.intel.tss2.Tabrmd"/>
   </policy>
-  <policy context="default">
+  <!-- Match /dev/tpmrm0 permissions tss tss 0660 -->
+  <policy user="root">
+    <allow send_destination="com.intel.tss2.Tabrmd"/>
+    <allow receive_sender="com.intel.tss2.Tabrmd"/>
+  </policy>
+  <policy group="root">
+    <allow send_destination="com.intel.tss2.Tabrmd"/>
+    <allow receive_sender="com.intel.tss2.Tabrmd"/>
+  </policy>
+  <policy user="tss">
+    <allow send_destination="com.intel.tss2.Tabrmd"/>
+    <allow receive_sender="com.intel.tss2.Tabrmd"/>
+  </policy>
+  <policy group="tss">
     <allow send_destination="com.intel.tss2.Tabrmd"/>
     <allow receive_sender="com.intel.tss2.Tabrmd"/>
   </policy>


### PR DESCRIPTION
The in-kernel resource manager (RM) has permissions of:
  tss(user) tss(group) 0660(mode)

Currently the tpm2-abrmd systemd conf allows for anyone to connect to
the dbus service and use the TPM, while this in and of itself is allowed
per the spec and whom can access to the TPM should not be used in your
threat modeling (assume access), it would be nice to match the in-kernel
RM and prevent any surprises.

Signed-off-by: William Roberts <william.c.roberts@intel.com>