### PR TITLE
SELinux: Add new interfaces for communication with keylime

### DIFF
--- a/selinux/tabrmd.if
+++ b/selinux/tabrmd.if
@@ -1,1 +1,41 @@
 ## <summary></summary>
+
+########################################
+## <summary>
+##      Create and use a unix stream socket
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`tabrmd_create_unix_stream_sockets',`
+        gen_require(`
+                type tabrmd_t;
+        ')
+
+        allow $1 tabrmd_t:unix_stream_socket create_stream_socket_perms;
+')
+
+########################################
+## <summary>
+##      Send messages to and from 
+##      tabrmd over DBUS.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`tabr,d_dbus_chat',`
+        gen_require(`
+                type tabrmd_t;
+                class dbus send_msg;
+        ')
+
+        allow $1 tabrmd_t:dbus send_msg;
+        allow tabrmd_t $1:dbus send_msg;
+')
+


### PR DESCRIPTION
Policy need rules to communicate with keylime.

AVC:
allow keylime_agent_t tabrmd_t:dbus send_msg;
allow keylime_agent_t tabrmd_t:unix_stream_socket { getattr getopt read write };

Create new interfaces to allow keylime
communicate with keylime.

[keylime-selinux](https://github.com/Koncpa/keylime-selinux)