### PR TITLE
resource-manager: bypass command_special_processing when session is p…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,7 +67,8 @@ TESTS_INTEGRATION = \
     test/integration/not-enough-handles-for-command.int \
     test/integration/password-authorization.int \
     test/integration/tpm2-command-flush-no-handle.int \
-    test/integration/util-buf-max-upper-bound.int
+    test/integration/util-buf-max-upper-bound.int \
+    test/integration/get-capability-with-session.int
 
 TESTS_INTEGRATION_NOHW = test/integration/tcti-connect-multiple.int
 
@@ -526,6 +527,10 @@ test_integration_tpm2_command_flush_no_handle_int_SOURCES = \
 test_integration_util_buf_max_upper_bound_int_LDADD = $(TEST_INT_LIBS)
 test_integration_util_buf_max_upper_bound_int_SOURCES = \
     test/integration/main.c test/integration/util-buf-max-upper-bound.int.c
+
+test_integration_get_capability_with_session_int_LDADD = $(TEST_INT_LIBS)
+test_integration_get_capability_with_session_int_SOURCES = \
+    test/integration/main.c test/integration/get-capability-with-session.int.c
 
 if WITH_SEPOLICY
 

--- a/src/resource-manager.c
+++ b/src/resource-manager.c
@@ -1121,8 +1121,10 @@ command_special_processing (ResourceManager *resmgr,
         response = resource_manager_load_context (resmgr, command);
         break;
     case TPM2_CC_GetCapability:
-        g_debug ("processing TPM2_CC_GetCapability");
-        response = get_cap_gen_response (resmgr, command);
+        if (!tpm2_command_has_auths(command)) {
+            g_debug ("processing TPM2_CC_GetCapability");
+            response = get_cap_gen_response (resmgr, command);
+        }
         break;
     default:
         break;

--- a/test/integration/common.h
+++ b/test/integration/common.h
@@ -80,6 +80,12 @@ start_auth_session (
     TPMI_SH_AUTH_SESSION  *session_handle
     );
 
+TSS2_RC
+start_auth_session_hmac (
+    TSS2_SYS_CONTEXT      *sapi_context,
+    TPMI_SH_AUTH_SESSION  *session_handle
+    );
+
 void
 prettyprint_context (
     TPMS_CONTEXT *context

--- a/test/integration/get-capability-with-session.int.c
+++ b/test/integration/get-capability-with-session.int.c
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+#include <glib.h>
+
+#include "common.h"
+
+/* test that TPM2_GetCapability works with an audit session and fails
+ * with a password session.
+ */
+int
+test_invoke (TSS2_SYS_CONTEXT *sapi_context) {
+    TSS2_RC rc = 0, expected_rc =
+        (TPM2_RC_HANDLE | TPM2_RC_S | TPM2_RC_1);
+    TPM2_HANDLE session;
+    TSS2L_SYS_AUTH_COMMAND cmdauths = {.count = 1 };
+    TSS2L_SYS_AUTH_RESPONSE respauths;
+    TPMI_YES_NO more = 0;
+    TPMS_CAPABILITY_DATA capdata;
+
+    cmdauths.auths[0].sessionHandle = TPM2_RH_PW;
+
+    rc = Tss2_Sys_GetCapability(sapi_context,
+				&cmdauths,
+				TPM2_CAP_PCRS,
+				0,
+				0,
+				&more,
+				&capdata,
+				&respauths);
+
+    if (rc != (TPM2_RC_HANDLE | TPM2_RC_S | TPM2_RC_1)) {
+        g_warning("Tss2_Sys_GetCapability with password session "
+		  "failed with 0x%x, expected 0x%x", rc, expected_rc);
+        return rc;
+    }
+
+    rc = start_auth_session_hmac(sapi_context, &session);
+    if (rc) {
+        g_warning("start_auth_session_hmac failed with 0x%x", rc);
+        return rc;
+    }
+
+    cmdauths.auths[0].sessionHandle = session;
+    cmdauths.auths[0].sessionAttributes |= TPMA_SESSION_AUDIT;
+
+    rc = Tss2_Sys_GetCapability(sapi_context,
+				&cmdauths,
+				TPM2_CAP_PCRS,
+				0,
+				0,
+				&more,
+				&capdata,
+				&respauths);
+    if (rc) {
+        g_warning("Tss2_Sys_GetCapability with audit session failed "
+		  "with 0x%x", rc);
+    return rc;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
…rovided

TPM2_GetCapability accepts an audit session, when specified no special processing should be done.
If a session without the audit flag set is passed let the TPM handle the error.

Fixes https://github.com/tpm2-software/tpm2-abrmd/issues/818