### PR TITLE
lgtm: disable policy lib fromt tpm2-tss

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -10,7 +10,7 @@ extraction:
     - git clone https://github.com/tpm2-software/tpm2-tss.git
     - cd tpm2-tss
     - ./bootstrap
-    - ./configure --prefix="$LGTM_WORKSPACE/installdir/usr" --disable-doxygen-doc --disable-esys --disable-fapi
+    - ./configure --prefix="$LGTM_WORKSPACE/installdir/usr" --disable-doxygen-doc --disable-esys --disable-fapi --disable-policy
     - make install
     - export PKG_CONFIG_PATH="$LGTM_WORKSPACE/installdir/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
     - export LD_LIBRARY_PATH="$LGTM_WORKSPACE/installdir/usr/lib:$LD_LIBRARY_PATH"


### PR DESCRIPTION
Avoids needing extra libs like JSONC.

Signed-off-by: William Roberts <william.c.roberts@intel.com>