### PR TITLE
Fix in SELinux interface file a typo

### DIFF
--- a/selinux/tabrmd.if
+++ b/selinux/tabrmd.if
@@ -29,7 +29,7 @@ interface(`tabrmd_create_unix_stream_sockets',`
 ##      </summary>
 ## </param>
 #
-interface(`tabr,d_dbus_chat',`
+interface(`tabrmd_dbus_chat',`
         gen_require(`
                 type tabrmd_t;
                 class dbus send_msg;


### PR DESCRIPTION
In name of interface in SELinux policy is
typo issue.

Signed-off-by: Patrik Koncity <pkoncity@redhat.com>