### PR TITLE
Add '/dev/tcm0' to default conf

### DIFF
--- a/src/tabrmd-defaults.h
+++ b/src/tabrmd-defaults.h
@@ -16,7 +16,7 @@
 #define TABRMD_ENTROPY_SRC_DEFAULT "/dev/urandom"
 #define TABRMD_SESSIONS_MAX_DEFAULT 4
 #define TABRMD_SESSIONS_MAX 64
-#define TABRMD_TCTI_CONF_DEFAULT "device:/dev/tpm0"
+#define TABRMD_TCTI_CONF_DEFAULT "device:/dev/tpm0;device:/dev/tcm0"
 #define TABRMD_TRANSIENT_MAX_DEFAULT 27
 #define TABRMD_TRANSIENT_MAX 100
 


### PR DESCRIPTION
A standard similar to TPM has been released in China, called TCM(Trusted Cryptography Module), and its device path is /dev/tcm0. 

The TCM standard is compatible with TPM, and TSS can be used to manage its device path.