### PR TITLE
Add file context entry for /usr/bin/tpm2-abrmd

### DIFF
--- a/selinux/tabrmd.fc
+++ b/selinux/tabrmd.fc
@@ -1,2 +1,3 @@
+/usr/bin/tpm2-abrmd	--	gen_context(system_u:object_r:tabrmd_exec_t,s0)
 /usr/sbin/tpm2-abrmd	--	gen_context(system_u:object_r:tabrmd_exec_t,s0)
 /usr/local/sbin/tpm2-abrmd	--	gen_context(system_u:object_r:tabrmd_exec_t,s0)


### PR DESCRIPTION
To comply with the "Unify bin and sbin" Fedora Change [1], file equivalency for the /bin, /sbin, and /usr/sbin paths are now set in selinux-policy to /usr/bin.
This requires follow-up changes in DSP modules, too.

[1] https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin