### PR TITLE
build: Drop deprecrated ACLOCAL_AMFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # we have BUILT_SOURCES so builddir must be in VPATH
 VPATH = $(srcdir) $(builddir)
-ACLOCAL_AMFLAGS = -I m4 --install
 
 .PHONY: unit-count
 


### PR DESCRIPTION
In parallel with https://github.com/tpm2-software/tpm2-tss/pull/2952