### PR TITLE
Introduce tabrmd_rw_unix_stream_sockets SELinux interface

### DIFF
--- a/selinux/tabrmd.if
+++ b/selinux/tabrmd.if
@@ -20,6 +20,24 @@ interface(`tabrmd_create_unix_stream_sockets',`
 
 ########################################
 ## <summary>
+##      Use a unix stream socket
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`tabrmd_rw_unix_stream_sockets',`
+        gen_require(`
+                type tabrmd_t;
+        ')
+
+        allow $1 tabrmd_t:unix_stream_socket rw_socket_perms;
+')
+
+########################################
+## <summary>
 ##      Send messages to and from
 ##      tabrmd over DBUS.
 ## </summary>


### PR DESCRIPTION
ATM there's only tabrmd_create_unix_stream_sockets, but some domains only need to use the socket, not create it.